### PR TITLE
Archive blocks <4786560 and update bronze models with union all

### DIFF
--- a/models/bronze/bronze__active_vault_events.sql
+++ b/models/bronze/bronze__active_vault_events.sql
@@ -15,3 +15,23 @@ FROM
     'thorchain_midgard',
     'midgard_active_vault_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  add_asgard_addr,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_active_vault_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__add_events.sql
+++ b/models/bronze/bronze__add_events.sql
@@ -23,3 +23,31 @@ FROM
     'thorchain_midgard',
     'midgard_add_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  memo,
+  rune_e8,
+  pool,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_add_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__asgard_fund_yggdrasil_events.sql
+++ b/models/bronze/bronze__asgard_fund_yggdrasil_events.sql
@@ -18,3 +18,25 @@ FROM
     'thorchain_midgard',
     'midgard_asgard_fund_yggdrasil_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+SELECT
+  tx,
+  asset,
+  asset_e8,
+  vault_key,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_asgard_fund_yggdrasil_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__asgard_fund_yggdrasil_events.sql
+++ b/models/bronze/bronze__asgard_fund_yggdrasil_events.sql
@@ -22,6 +22,7 @@ WHERE
   block_timestamp >= 1647913096219785087
 
 UNION ALL
+
 SELECT
   tx,
   asset,

--- a/models/bronze/bronze__block_log.sql
+++ b/models/bronze/bronze__block_log.sql
@@ -16,3 +16,24 @@ FROM
     'thorchain_midgard',
     'midgard_block_log'
   ) }}
+WHERE 
+  TIMESTAMP >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  height,
+  TIMESTAMP,
+  HASH,
+  agg_state,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_block_log'
+  ) }}
+WHERE 
+  TIMESTAMP < 1647913096219785087

--- a/models/bronze/bronze__block_pool_depths.sql
+++ b/models/bronze/bronze__block_pool_depths.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_block_pool_depths'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+SELECT
+  pool,
+  asset_e8,
+  rune_e8,
+  synth_e8,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_block_pool_depths'
+  ) }}
+
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__block_pool_depths.sql
+++ b/models/bronze/bronze__block_pool_depths.sql
@@ -21,6 +21,7 @@ WHERE
   block_timestamp >= 1647913096219785087
 
 UNION ALL
+
 SELECT
   pool,
   asset_e8,

--- a/models/bronze/bronze__bond_events.sql
+++ b/models/bronze/bronze__bond_events.sql
@@ -42,6 +42,7 @@ WHERE
   block_timestamp >= 1647913096219785087
 
 UNION ALL
+
 SELECT
   tx,
   COALESCE(

--- a/models/bronze/bronze__bond_events.sql
+++ b/models/bronze/bronze__bond_events.sql
@@ -38,3 +38,45 @@ FROM
     'thorchain_midgard',
     'midgard_bond_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+SELECT
+  tx,
+  COALESCE(
+    chain,
+    ''
+  ) AS chain,
+  COALESCE(
+    from_addr,
+    ''
+  ) AS from_addr,
+  COALESCE(
+    to_addr,
+    ''
+  ) AS to_addr,
+  COALESCE(
+    asset,
+    ''
+  ) AS asset,
+  asset_e8,
+  COALESCE(
+    memo,
+    ''
+  ) AS memo,
+  COALESCE(
+    bond_type,
+    ''
+  ) AS bond_type,
+  e8,
+  block_timestamp,
+  event_id,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_bond_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__errata_events.sql
+++ b/models/bronze/bronze__errata_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_errata_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  in_tx,
+  asset,
+  asset_e8,
+  rune_e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_errata_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__fee_events.sql
+++ b/models/bronze/bronze__fee_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_fee_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  asset,
+  asset_e8,
+  pool_deduct,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_fee_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__gas_events.sql
+++ b/models/bronze/bronze__gas_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_gas_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  asset,
+  asset_e8,
+  rune_e8,
+  tx_count,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_gas_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__inactive_vault_events.sql
+++ b/models/bronze/bronze__inactive_vault_events.sql
@@ -15,3 +15,23 @@ FROM
     'thorchain_midgard',
     'midgard_inactive_vault_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  add_asgard_addr,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_inactive_vault_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__loan_open_events.sql
+++ b/models/bronze/bronze__loan_open_events.sql
@@ -23,3 +23,31 @@ FROM
     'thorchain_midgard',
     'midgard_loan_open_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  owner,
+  collateral_up,
+  debt_up,
+  collateralization_ratio,
+  collateral_asset,
+  target_asset,
+  event_id,
+  collateral_deposited,
+  debt_issued,
+  tx_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_loan_open_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__loan_repayment_events.sql
+++ b/models/bronze/bronze__loan_repayment_events.sql
@@ -21,3 +21,29 @@ FROM
     'thorchain_midgard',
     'midgard_loan_repayment_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  owner,
+  collateral_down,
+  debt_down,
+  collateral_asset,
+  event_id,
+  block_timestamp,
+  collateral_withdrawn,
+  debt_repaid,
+  tx_id,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_loan_repayment_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__mint_burn_events.sql
+++ b/models/bronze/bronze__mint_burn_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_mint_burn_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  asset,
+  asset_e8,
+  supply,
+  reason,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_mint_burn_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__network_version_events.sql
+++ b/models/bronze/bronze__network_version_events.sql
@@ -15,3 +15,23 @@ FROM
     'thorchain_midgard',
     'midgard_network_version_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  version,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_network_version_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__new_node_events.sql
+++ b/models/bronze/bronze__new_node_events.sql
@@ -15,3 +15,23 @@ FROM
     'thorchain_midgard',
     'midgard_new_node_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_addr,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_new_node_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__outbound_events.sql
+++ b/models/bronze/bronze__outbound_events.sql
@@ -22,3 +22,30 @@ FROM
     'thorchain_midgard',
     'midgard_outbound_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  memo,
+  in_tx,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_outbound_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__pending_liquidity_events.sql
+++ b/models/bronze/bronze__pending_liquidity_events.sql
@@ -23,3 +23,31 @@ FROM
     'thorchain_midgard',
     'midgard_pending_liquidity_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  pool,
+  asset_tx,
+  asset_chain,
+  asset_addr,
+  asset_e8,
+  rune_tx,
+  rune_addr,
+  rune_e8,
+  pending_type,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_pending_liquidity_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__pool_balance_change_events.sql
+++ b/models/bronze/bronze__pool_balance_change_events.sql
@@ -20,3 +20,28 @@ FROM
     'thorchain_midgard',
     'midgard_pool_balance_change_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  asset,
+  rune_amt,
+  rune_add,
+  asset_amt,
+  asset_add,
+  reason,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_pool_balance_change_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__pool_events.sql
+++ b/models/bronze/bronze__pool_events.sql
@@ -16,3 +16,24 @@ FROM
     'thorchain_midgard',
     'midgard_pool_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  asset,
+  status,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_pool_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__refund_events.sql
+++ b/models/bronze/bronze__refund_events.sql
@@ -25,3 +25,33 @@ FROM
     'thorchain_midgard',
     'midgard_refund_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  asset_2nd,
+  asset_2nd_e8,
+  memo,
+  code,
+  reason,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_refund_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__reserve_events.sql
+++ b/models/bronze/bronze__reserve_events.sql
@@ -23,3 +23,31 @@ FROM
     'thorchain_midgard',
     'midgard_reserve_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  memo,
+  addr,
+  e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_reserve_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__rewards_event_entries.sql
+++ b/models/bronze/bronze__rewards_event_entries.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_rewards_event_entries'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  pool,
+  rune_e8,
+  saver_e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_rewards_event_entries'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__rewards_events.sql
+++ b/models/bronze/bronze__rewards_events.sql
@@ -15,3 +15,23 @@ FROM
     'thorchain_midgard',
     'midgard_rewards_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  bond_e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_rewards_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__set_ip_address_events.sql
+++ b/models/bronze/bronze__set_ip_address_events.sql
@@ -16,3 +16,24 @@ FROM
     'thorchain_midgard',
     'midgard_set_ip_address_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_addr,
+  ip_addr,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_set_ip_address_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__set_mimir_events.sql
+++ b/models/bronze/bronze__set_mimir_events.sql
@@ -16,3 +16,24 @@ FROM
     'thorchain_midgard',
     'midgard_set_mimir_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  key,
+  VALUE,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_set_mimir_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__set_node_keys_events.sql
+++ b/models/bronze/bronze__set_node_keys_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_set_node_keys_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_addr,
+  secp256k1,
+  ed25519,
+  validator_consensus,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_set_node_keys_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__set_version_events.sql
+++ b/models/bronze/bronze__set_version_events.sql
@@ -16,3 +16,24 @@ FROM
     'thorchain_midgard',
     'midgard_set_version_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_addr,
+  version,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_set_version_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__slash_amounts.sql
+++ b/models/bronze/bronze__slash_amounts.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_slash_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  pool,
+  asset,
+  asset_e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_slash_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__slash_points.sql
+++ b/models/bronze/bronze__slash_points.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_slash_points_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_address,
+  slash_points,
+  reason,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_slash_points_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__stake_events.sql
+++ b/models/bronze/bronze__stake_events.sql
@@ -24,3 +24,32 @@ FROM
     'thorchain_midgard',
     'midgard_stake_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  pool,
+  asset_tx,
+  asset_chain,
+  asset_addr,
+  asset_e8,
+  stake_units,
+  rune_tx,
+  rune_addr,
+  rune_e8,
+  _ASSET_IN_RUNE_E8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_stake_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__streamling_swap_details_events.sql
+++ b/models/bronze/bronze__streamling_swap_details_events.sql
@@ -27,3 +27,35 @@ FROM
     'thorchain_midgard',
     'midgard_streaming_swap_details_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx_id,
+  INTERVAL,
+  quantity,
+  COUNT,
+  last_height,
+  deposit_asset,
+  deposit_e8,
+  in_asset,
+  in_e8,
+  out_asset,
+  out_e8,
+  failed_swaps,
+  failed_swaps_reasons,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_streaming_swap_details_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__swap_events.sql
+++ b/models/bronze/bronze__swap_events.sql
@@ -31,3 +31,39 @@ FROM
     'thorchain_midgard',
     'midgard_swap_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  from_asset,
+  from_e8,
+  to_asset,
+  to_e8,
+  memo,
+  pool,
+  to_e8_min,
+  swap_slip_bp,
+  liq_fee_e8,
+  liq_fee_in_rune_e8,
+  _DIRECTION,
+  event_id,
+  block_timestamp,
+  streaming_count,
+  streaming_quantity,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_swap_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__switch_events.sql
+++ b/models/bronze/bronze__switch_events.sql
@@ -32,3 +32,40 @@ FROM
     'thorchain_midgard',
     'midgard_switch_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  COALESCE(
+    tx,
+    ''
+  ) AS tx,
+  COALESCE(
+    from_addr,
+    ''
+  ) AS from_addr,
+  COALESCE(
+    to_addr,
+    ''
+  ) AS to_addr,
+  COALESCE(
+    burn_asset,
+    ''
+  ) AS burn_asset,
+  burn_e8,
+  mint_e8,
+  block_timestamp,
+  event_id,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_switch_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__thorname_change_events.sql
+++ b/models/bronze/bronze__thorname_change_events.sql
@@ -21,3 +21,29 @@ FROM
     'thorchain_midgard',
     'midgard_thorname_change_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  NAME,
+  chain,
+  address,
+  registration_fee_e8,
+  fund_amount_e8,
+  expire,
+  owner,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_thorname_change_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__transfer_events.sql
+++ b/models/bronze/bronze__transfer_events.sql
@@ -18,3 +18,26 @@ FROM
     'thorchain_midgard',
     'midgard_transfer_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  from_addr,
+  to_addr,
+  asset,
+  amount_e8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_transfer_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__tss_keygen_failure_events.sql
+++ b/models/bronze/bronze__tss_keygen_failure_events.sql
@@ -19,3 +19,27 @@ FROM
     'thorchain_midgard',
     'midgard_tss_keygen_failure_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  fail_reason,
+  is_unicast,
+  blame_nodes,
+  ROUND,
+  height,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_tss_keygen_failure_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__tss_keygen_success_events.sql
+++ b/models/bronze/bronze__tss_keygen_success_events.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_tss_keygen_success_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  pub_key,
+  members,
+  height,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_tss_keygen_success_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__unstake_events.sql
+++ b/models/bronze/bronze__unstake_events.sql
@@ -30,3 +30,37 @@ FROM
     'thorchain_midgard',
     'midgard_unstake_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  emit_asset_e8,
+  emit_rune_e8,
+  memo,
+  pool,
+  stake_units,
+  basis_points,
+  asymmetry,
+  imp_loss_protection_e8,
+  _EMIT_ASSET_IN_RUNE_E8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_unstake_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__update_node_account_status_events.sql
+++ b/models/bronze/bronze__update_node_account_status_events.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_update_node_account_status_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  node_addr,
+  "CURRENT" AS current_flag,
+  former,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_update_node_account_status_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__validator_request_leave_events.sql
+++ b/models/bronze/bronze__validator_request_leave_events.sql
@@ -17,3 +17,25 @@ FROM
     'thorchain_midgard',
     'midgard_validator_request_leave_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  from_addr,
+  node_addr,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_validator_request_leave_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/bronze/bronze__withdraw_events.sql
+++ b/models/bronze/bronze__withdraw_events.sql
@@ -29,3 +29,37 @@ FROM
     'thorchain_midgard',
     'midgard_withdraw_events'
   ) }}
+WHERE 
+  block_timestamp >= 1647913096219785087
+
+UNION ALL
+
+SELECT
+  tx,
+  chain,
+  from_addr,
+  to_addr,
+  asset,
+  asset_e8,
+  emit_asset_e8,
+  emit_rune_e8,
+  memo,
+  pool,
+  stake_units,
+  basis_points,
+  asymmetry,
+  imp_loss_protection_e8,
+  _EMIT_ASSET_IN_RUNE_E8,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard_archive',
+    'midgard_withdraw_events'
+  ) }}
+WHERE 
+  block_timestamp < 1647913096219785087

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -56,6 +56,56 @@ sources:
       - name: midgard_update_node_account_status_events
       - name: midgard_validator_request_leave_events
       - name: midgard_withdraw_events
+  - name: thorchain_midgard_archive  # pre block 4786560
+    database: HEVO
+    schema: THORCHAIN_MIDGARD_ARCHIVE
+    tables:
+      - name: midgard_active_vault_events
+      - name: midgard_add_events
+      - name: midgard_asgard_fund_yggdrasil_events
+      - name: midgard_block_log
+      - name: midgard_block_pool_depths
+      - name: midgard_bond_events
+      - name: bond_events_pk_count
+      - name: midgard_constants
+      - name: midgard_errata_events
+      - name: midgard_fee_events
+      - name: fee_events_pk_count
+      - name: midgard_gas_events
+      - name: midgard_inactive_vault_events
+      - name: midgard_loan_open_events
+      - name: midgard_loan_repayment_events
+      - name: midgard_message_events
+      - name: midgard_mint_burn_events
+      - name: midgard_network_version_events
+      - name: midgard_new_node_events
+      - name: midgard_outbound_events
+      - name: midgard_pending_liquidity_events
+      - name: midgard_pool_balance_change_events
+      - name: midgard_pool_events
+      - name: midgard_refund_events
+      - name: midgard_reserve_events
+      - name: midgard_rewards_event_entries
+      - name: midgard_rewards_events
+      - name: midgard_set_ip_address_events
+      - name: midgard_set_mimir_events
+      - name: midgard_set_node_keys_events
+      - name: midgard_set_version_events
+      - name: midgard_slash_events
+      - name: midgard_slash_points_events
+      - name: midgard_stake_events
+      - name: midgard_streaming_swap_details_events
+      - name: midgard_swap_events
+      - name: midgard_switch_events
+      - name: switch_events_pk_count
+      - name: midgard_thorname_change_events
+      - name: midgard_transfer_events
+      - name: midgard_tss_keygen_failure_events
+      - name: midgard_tss_keygen_success_events
+      - name: midgard_unstake_events
+      - name: midgard_update_node_account_status_events
+      - name: midgard_validator_request_leave_events
+      - name: midgard_withdraw_events
   - name: crosschain
     database: "{{ 'crosschain' if target.database == 'THORCHAIN' else 'crosschain_dev' }}"
     schema: core


### PR DESCRIPTION
The midgard indexer update will no longer support these old blocks prior to `2022-03-22 01:38:16.219`.

This PR incorporates the following changes:
1. A new schema `HEVO.THORCHAIN_MIDGARD_ARCHIVE`, which clones `HEVO.THORCHAIN_MIDGARD`
2. An updated dbt `sources.yml` that includes tables in `HEVO.THORCHAIN_MIDGARD_ARCHIVE`
3. Updated bronze models that union new and archived data using the following pattern:
```
SELECT ...
FROM thorchain_midgard.*
WHERE block_timestamp >= 1647913096219785087

UNION ALL

SELECT ...
FROM thorchain_midgard_archive.*
WHERE block_timestamp < 1647913096219785087
```

The only table not included was `bronze__constants` as it only includes key value pairs with no timestamp column.