### PR TITLE
removed tests that were failing for potentially accurate data

### DIFF
--- a/models/silver/silver__scheduled_outbound_events.yml
+++ b/models/silver/silver__scheduled_outbound_events.yml
@@ -30,14 +30,8 @@ models:
           - not_null
       - name: OUT_HASH
       - name: MAX_GAS_AMOUNT
-        tests:
-          - not_null
       - name: MAX_GAS_DECIMALS
-        tests:
-          - not_null
       - name: MAX_GAS_ASSET
-        tests:
-          - not_null
       - name: MODULE_NAME
       - name: VAULT_PUB_KEY
         tests:


### PR DESCRIPTION
This PR removes null value tests for three columns in `midgard_scheduled_outbound_events`.

While this table was introduced in July 2024, block timestamps show nulls going as far back as May 2022 and as recently as May 2024. This might mean that the events were scheduled from long ago:

```sql
select 
  min(block_timestamp), 
  max(block_timestamp)
from 
  hevo.thorchain_midgard_2_22_3.midgard_scheduled_outbound_events 
where 
  max_gas_asset is not null;
```

The null values account for 0.05% of all rows in this table and are nearly exclusively `where asset = THOR.RUNE`.

More context here: https://flipsidecrypto.slack.com/archives/C04JZC78D0Q/p1720489456331449