### PR TITLE
turning on incremental loads in dev. was it really this simple?

### DIFF
--- a/.github/workflows/dbt_run_dev_incremental.yml
+++ b/.github/workflows/dbt_run_dev_incremental.yml
@@ -23,7 +23,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_dev
 
     steps:
       - uses: actions/checkout@v3
@@ -38,4 +38,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run-operation run_sp_create_prod_clone
+          dbt run -s ./models

--- a/.github/workflows/dbt_run_dev_incremental.yml
+++ b/.github/workflows/dbt_run_dev_incremental.yml
@@ -1,5 +1,5 @@
-name: dbt_run_dev_refresh
-run-name: dbt_run_dev_refresh
+name: dbt_run_dev_incremental
+run-name: dbt_run_dev_incremental
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -38,4 +38,5 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run-operation run_sp_create_prod_clone
+          dbt run -s ./models --vars '{"target_database": "thorchain_dev"}'
+

--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -38,5 +38,5 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models -t
+          dbt run -s ./models -t dev
 

--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -38,5 +38,5 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models --vars '{"target_database": "thorchain_dev"}'
+          dbt run -s ./models -t
 


### PR DESCRIPTION
I wandered too far out of scope with my previous solution... but it was a great learning opportunity.

Here I swap out the prod --> dev clone macro with a `target_database` variable and more importantly turn off `--full-refresh`. 

Expected behavior: once per hour, all gold models will refresh incrementally. I can then:
1. Identify and resolve any transformation issues
2. Compare resource usage for prod vs. dev