### PR TITLE
incremental logic fixes and efficiency gains

### DIFF
--- a/.github/workflows/dbt_run_dev_incremental.yml
+++ b/.github/workflows/dbt_run_dev_incremental.yml
@@ -38,4 +38,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models
+          dbt run -s "thorchain_models,./models"

--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -38,4 +38,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models --full-refresh
+          dbt run -s ./models

--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -38,4 +38,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models --full-refresh
+          dbt run -s "thorchain_models,./models" --full-refresh

--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -38,4 +38,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s ./models
+          dbt run -s ./models --full-refresh

--- a/macros/custom_naming_macros.sql
+++ b/macros/custom_naming_macros.sql
@@ -15,3 +15,9 @@
     {% set split_name = node_name.split('__') %}
     {{ split_name [1] | trim }}
 {%- endmacro %}
+
+{% macro generate_tmp_view_name(model_name) -%}
+    {% set node_name = model_name.name %}
+    {% set split_name = node_name.split('__') %}
+    {{ target.database ~ '.' ~ split_name[0] ~ '.' ~ split_name [1] ~ '__dbt_tmp' | trim }}
+{%- endmacro %}

--- a/models/gold/core/core__dim_block.sql
+++ b/models/gold/core/core__dim_block.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = 'dim_block_id',
     incremental_strategy = 'merge',
-    incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
+    incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
     cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__dim_block.sql
+++ b/models/gold/core/core__dim_block.sql
@@ -40,7 +40,7 @@ WHERE
             )
         FROM
             {{ this }}
-    ) - INTERVAL '48 HOURS'
+    ) 
 {% endif %}
 UNION ALL
 SELECT

--- a/models/gold/core/core__dim_block.sql
+++ b/models/gold/core/core__dim_block.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     unique_key = 'dim_block_id',
     incremental_strategy = 'merge',
+    incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],
     cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -39,7 +40,7 @@ WHERE
             )
         FROM
             {{ this }}
-    ) - INTERVAL '72 HOURS'
+    ) - INTERVAL '48 HOURS'
 {% endif %}
 UNION ALL
 SELECT

--- a/models/gold/core/core__dim_block.sql
+++ b/models/gold/core/core__dim_block.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = 'dim_block_id',
     incremental_strategy = 'merge',
-    incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],
+    incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
     cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_network_version_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_network_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -26,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -34,7 +34,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -42,7 +42,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_network_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_network_version_events.sql
+++ b/models/gold/core/core__fact_network_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_network_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -16,18 +16,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__network_version_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -49,3 +37,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_mimir_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],  
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],  
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_mimir_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -17,18 +17,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__set_mimir_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -50,3 +38,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -27,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_mimir_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],  
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -35,7 +35,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -43,7 +43,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_set_mimir_events.sql
+++ b/models/gold/core/core__fact_set_mimir_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_mimir_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],  
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_thorname_change_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -45,7 +45,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -53,7 +53,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -32,7 +32,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_thorname_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_thorname_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_thorname_change_events.sql
+++ b/models/gold/core/core__fact_thorname_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_thorname_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -22,18 +22,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__thorname_change_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -60,3 +48,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfer_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfer_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfer_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_transfer_events.sql
+++ b/models/gold/core/core__fact_transfer_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfer_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,18 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__transfer_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -54,3 +42,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfers_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfers_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -23,10 +23,10 @@ WITH base AS (
 
 {% if is_incremental() %}
 WHERE
-  _inserted_timestamp >= (
+  block_timestamp >= (
     SELECT
       MAX(
-        _inserted_timestamp
+        block_timestamp
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfers_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -30,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -26,7 +26,7 @@ WHERE
   block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
@@ -53,6 +53,6 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_transfers_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_failure_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -20,18 +20,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__tss_keygen_failure_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -57,3 +45,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -42,7 +42,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -50,7 +50,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_failure_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_failure_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_failure_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_failure_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_failure_events.sql
@@ -30,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -38,7 +38,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -46,7 +46,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_success_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__tss_keygen_success_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -53,3 +41,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_success_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_success_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/core/core__fact_tss_keygen_success_events.sql
+++ b/models/gold/core/core__fact_tss_keygen_success_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_tss_keygen_success_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_active_vault_events.sql
+++ b/models/gold/defi/defi__fact_active_vault_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_active_vault_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -25,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR add_asgard_addr IN (
     SELECT
       add_asgard_addr

--- a/models/gold/defi/defi__fact_active_vault_events.sql
+++ b/models/gold/defi/defi__fact_active_vault_events.sql
@@ -33,7 +33,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -41,17 +41,9 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
   ) 
-  OR add_asgard_addr IN (
-    SELECT
-      add_asgard_addr
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
 {% endif %}

--- a/models/gold/defi/defi__fact_active_vault_events.sql
+++ b/models/gold/defi/defi__fact_active_vault_events.sql
@@ -26,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR add_asgard_addr IN (
     SELECT
       add_asgard_addr

--- a/models/gold/defi/defi__fact_active_vault_events.sql
+++ b/models/gold/defi/defi__fact_active_vault_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_active_vault_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_active_vault_events.sql
+++ b/models/gold/defi/defi__fact_active_vault_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_active_vault_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -36,7 +36,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_add_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -35,7 +36,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_add_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -51,7 +51,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -59,7 +59,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_add_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_add_events.sql
+++ b/models/gold/defi/defi__fact_add_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_add_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -24,28 +24,7 @@ WITH base AS (
     e._TX_TYPE,
     _inserted_timestamp
   FROM
-    {{ ref('silver__add_events') }}
-    e
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR tx_id IN (
-    SELECT
-      tx_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
+    {{ ref('silver__add_events') }} e
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -75,3 +54,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_asgard_fund_yggdrasil_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,26 +19,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__asgard_fund_yggdrasil_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR tx_id IN (
-    SELECT
-      tx_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -62,3 +42,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_asgard_fund_yggdrasil_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_asgard_fund_yggdrasil_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -28,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
+++ b/models/gold/defi/defi__fact_asgard_fund_yggdrasil_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_asgard_fund_yggdrasil_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_depths_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -38,7 +38,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -46,7 +46,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_depths_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,26 +18,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__block_pool_depths') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR pool_name IN (
-    SELECT
-      pool_name
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -61,3 +41,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR pool_name IN (
+    SELECT
+      pool_name
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_depths_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)],
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_depths_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -27,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '72 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR pool_name IN (
     SELECT
       pool_name

--- a/models/gold/defi/defi__fact_block_pool_depths.sql
+++ b/models/gold/defi/defi__fact_block_pool_depths.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR pool_name IN (
     SELECT
       pool_name

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_block_rewards_id',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_block_rewards_id',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_block_rewards_id',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -25,7 +25,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_block_rewards_id',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_block_rewards.sql
+++ b/models/gold/defi/defi__fact_block_rewards.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = "fact_bond_actions_id",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -63,7 +63,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   bond_events be
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON be.block_timestamp = b.timestamp
   LEFT JOIN block_prices p
@@ -73,7 +73,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = "fact_bond_actions_id",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = "fact_bond_actions_id",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -43,7 +44,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -44,7 +44,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_bond_actions.sql
+++ b/models/gold/defi/defi__fact_bond_actions.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = "fact_bond_actions_id",
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -34,26 +34,6 @@ bond_events AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__bond_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR tx_id IN (
-    SELECT
-      tx_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -88,3 +68,22 @@ FROM
   ON be.block_timestamp = b.timestamp
   LEFT JOIN block_prices p
   ON b.block_id = p.block_id
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -34,7 +34,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_bond_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_bond_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -24,26 +24,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__bond_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR tx_id IN (
-    SELECT
-      tx_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -73,3 +53,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -50,7 +50,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -58,7 +58,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_bond_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -33,7 +34,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_bond_events.sql
+++ b/models/gold/defi/defi__fact_bond_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_bond_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -34,7 +34,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_earnings_id',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_earnings_id',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -30,7 +30,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_earnings_id',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_earnings.sql
+++ b/models/gold/defi/defi__fact_daily_earnings.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_earnings_id',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_pool_stats.sql
+++ b/models/gold/defi/defi__fact_daily_pool_stats.sql
@@ -61,7 +61,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_daily_pool_stats.sql
+++ b/models/gold/defi/defi__fact_daily_pool_stats.sql
@@ -3,7 +3,6 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_pool_stats_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -3, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_pool_stats.sql
+++ b/models/gold/defi/defi__fact_daily_pool_stats.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_pool_stats_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_pool_stats.sql
+++ b/models/gold/defi/defi__fact_daily_pool_stats.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_pool_stats_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -2, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_pool_stats.sql
+++ b/models/gold/defi/defi__fact_daily_pool_stats.sql
@@ -58,7 +58,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_daily_tvl.sql
+++ b/models/gold/defi/defi__fact_daily_tvl.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_daily_tvl.sql
+++ b/models/gold/defi/defi__fact_daily_tvl.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_tvl_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_tvl.sql
+++ b/models/gold/defi/defi__fact_daily_tvl.sql
@@ -25,7 +25,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_daily_tvl.sql
+++ b/models/gold/defi/defi__fact_daily_tvl.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_tvl_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -2, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_daily_tvl.sql
+++ b/models/gold/defi/defi__fact_daily_tvl.sql
@@ -3,7 +3,6 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_daily_tvl_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -3, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_errata_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_errata_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -28,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_errata_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,26 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__errata_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR asset IN (
-    SELECT
-      asset
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -62,3 +42,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR asset IN (
+    SELECT
+      asset
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_errata_events.sql
+++ b/models/gold/defi/defi__fact_errata_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_errata_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_fee_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -28,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_fee_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR tx_id IN (
     SELECT
       tx_id

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_fee_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_fee_events.sql
+++ b/models/gold/defi/defi__fact_fee_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_fee_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,26 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__fee_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR tx_id IN (
-    SELECT
-      tx_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -62,3 +42,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_gas_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -28,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_gas_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,26 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__gas_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR asset IN (
-    SELECT
-      asset
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -62,3 +42,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR asset IN (
+    SELECT
+      asset
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_gas_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_gas_events.sql
+++ b/models/gold/defi/defi__fact_gas_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_gas_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_inactive_vault_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -16,26 +16,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__inactive_vault_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR add_asgard_address IN (
-    SELECT
-      add_asgard_address
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -56,3 +36,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR add_asgard_address IN (
+    SELECT
+      add_asgard_address
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_inactive_vault_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_inactive_vault_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -25,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR add_asgard_address IN (
     SELECT
       add_asgard_address

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -33,7 +33,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -41,17 +41,9 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
   ) 
-  OR add_asgard_address IN (
-    SELECT
-      add_asgard_address
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
 {% endif %}

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_inactive_vault_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_inactive_vault_events.sql
+++ b/models/gold/defi/defi__fact_inactive_vault_events.sql
@@ -26,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR add_asgard_address IN (
     SELECT
       add_asgard_address

--- a/models/gold/defi/defi__fact_liquidity_actions.sql
+++ b/models/gold/defi/defi__fact_liquidity_actions.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_liquidity_actions_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_liquidity_actions.sql
+++ b/models/gold/defi/defi__fact_liquidity_actions.sql
@@ -65,7 +65,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
 {% if is_incremental() %}
@@ -73,7 +73,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_liquidity_actions.sql
+++ b/models/gold/defi/defi__fact_liquidity_actions.sql
@@ -42,7 +42,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_liquidity_actions.sql
+++ b/models/gold/defi/defi__fact_liquidity_actions.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_liquidity_actions_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_liquidity_actions.sql
+++ b/models/gold/defi/defi__fact_liquidity_actions.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_liquidity_actions_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_open_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -35,7 +35,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_open_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -25,18 +25,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__loan_open_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -65,3 +53,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_open_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_open_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_open_events.sql
+++ b/models/gold/defi/defi__fact_loan_open_events.sql
@@ -50,7 +50,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -58,7 +58,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_repayment_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -48,7 +48,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -56,7 +56,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_repayment_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -33,7 +33,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_repayment_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_loan_repayment_events.sql
+++ b/models/gold/defi/defi__fact_loan_repayment_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_loan_repayment_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -23,18 +23,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__loan_repayment_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -63,3 +51,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_mint_burn_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_mint_burn_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,18 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__mint_burn_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -55,3 +43,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_mint_burn_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_mint_burn_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_mint_burn_events.sql
+++ b/models/gold/defi/defi__fact_mint_burn_events.sql
@@ -40,7 +40,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -48,7 +48,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_outbound_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -34,7 +34,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_outbound_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -24,18 +24,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__outbound_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -64,3 +52,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -49,7 +49,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -57,7 +57,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_outbound_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_outbound_events.sql
+++ b/models/gold/defi/defi__fact_outbound_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_outbound_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pending_liquidity_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pending_liquidity_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pending_liquidity_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -24,18 +24,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__pending_liquidity_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -64,3 +52,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -34,7 +34,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pending_liquidity_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pending_liquidity_events.sql
+++ b/models/gold/defi/defi__fact_pending_liquidity_events.sql
@@ -49,7 +49,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -57,7 +57,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_balance_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -43,7 +43,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -51,7 +51,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_balance_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -21,26 +21,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__pool_balance_change_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR asset IN (
-    SELECT
-      asset
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -66,3 +46,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR asset IN (
+    SELECT
+      asset
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_balance_change_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -30,7 +31,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_balance_change_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_balance_change_events.sql
+++ b/models/gold/defi/defi__fact_pool_balance_change_events.sql
@@ -31,7 +31,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_balances_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -22,18 +22,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__pool_block_balances') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -60,3 +48,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_balances_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_balances_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -32,7 +32,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -45,7 +45,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
 {% if is_incremental() %}
@@ -53,7 +53,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_block_balances.sql
+++ b/models/gold/defi/defi__fact_pool_block_balances.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_balances_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_fees.sql
+++ b/models/gold/defi/defi__fact_pool_block_fees.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_fees_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_fees.sql
+++ b/models/gold/defi/defi__fact_pool_block_fees.sql
@@ -27,7 +27,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_block_fees.sql
+++ b/models/gold/defi/defi__fact_pool_block_fees.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_fees_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'],
   cluster_by = ['day']
 ) }}
 
@@ -23,10 +24,10 @@ WITH base AS (
 
 {% if is_incremental() %}
 WHERE
-  _inserted_timestamp >= (
+  DAY >= (
     SELECT
       MAX(
-        _inserted_timestamp
+        DAY
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_block_fees.sql
+++ b/models/gold/defi/defi__fact_pool_block_fees.sql
@@ -3,7 +3,6 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_fees_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_fees.sql
+++ b/models/gold/defi/defi__fact_pool_block_fees.sql
@@ -30,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_pool_block_statistics.sql
+++ b/models/gold/defi/defi__fact_pool_block_statistics.sql
@@ -56,7 +56,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_block_statistics.sql
+++ b/models/gold/defi/defi__fact_pool_block_statistics.sql
@@ -59,7 +59,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_pool_block_statistics.sql
+++ b/models/gold/defi/defi__fact_pool_block_statistics.sql
@@ -3,7 +3,6 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_statistics_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -3, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_statistics.sql
+++ b/models/gold/defi/defi__fact_pool_block_statistics.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_statistics_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_block_statistics.sql
+++ b/models/gold/defi/defi__fact_pool_block_statistics.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_block_statistics_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.DAY" >= datediff(day, -2, current_date)], 
   cluster_by = ['day']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -17,26 +17,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__pool_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR asset IN (
-    SELECT
-      asset
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -58,3 +38,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR asset IN (
+    SELECT
+      asset
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -27,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -35,7 +35,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -43,7 +43,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_pool_events.sql
+++ b/models/gold/defi/defi__fact_pool_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_pool_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -26,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR asset IN (
     SELECT
       asset

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -37,7 +37,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_refund_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -54,7 +54,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -62,7 +62,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_refund_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -27,18 +27,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__refund_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -69,3 +57,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_refund_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_refund_events.sql
+++ b/models/gold/defi/defi__fact_refund_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_refund_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -35,7 +35,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_reserve_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -25,18 +25,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__reserve_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -66,3 +54,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_reserve_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_reserve_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_reserve_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_reserve_events.sql
+++ b/models/gold/defi/defi__fact_reserve_events.sql
@@ -51,7 +51,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -59,7 +59,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -37,7 +37,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -45,7 +45,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_event_entries_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_event_entries_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_event_entries_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__rewards_event_entries') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -52,3 +40,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_rewards_event_entries.sql
+++ b/models/gold/defi/defi__fact_rewards_event_entries.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_event_entries_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -26,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -16,18 +16,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__rewards_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -48,3 +36,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -33,7 +33,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -41,7 +41,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_rewards_events.sql
+++ b/models/gold/defi/defi__fact_rewards_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rewards_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -39,7 +39,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
       OR event_id IN (
         SELECT
           event_id

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -38,7 +39,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
       OR event_id IN (
         SELECT
           event_id

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -29,26 +29,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__scheduled_outbound_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-      OR event_id IN (
-        SELECT
-          event_id
-        FROM
-          {{ this }}
-        WHERE
-          dim_block_id = '-1'
-      )
-    {% endif %}
   )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -83,3 +63,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+      OR event_id IN (
+        SELECT
+          event_id
+        FROM
+          {{ this }}
+        WHERE
+          dim_block_id = '-1'
+      )
+    {% endif %}

--- a/models/gold/defi/defi__fact_scheduled_outbound_events.sql
+++ b/models/gold/defi/defi__fact_scheduled_outbound_events.sql
@@ -60,7 +60,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -68,17 +68,17 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
   ) 
-      OR event_id IN (
-        SELECT
-          event_id
-        FROM
-          {{ this }}
-        WHERE
-          dim_block_id = '-1'
-      )
-    {% endif %}
+  OR event_id IN (
+    SELECT
+      event_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -21,26 +21,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__send_messages') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR event_id IN (
-    SELECT
-      event_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -67,3 +47,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR event_id IN (
+    SELECT
+      event_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -31,7 +31,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR event_id IN (
     SELECT
       event_id

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_send_messages.sql
+++ b/models/gold/defi/defi__fact_send_messages.sql
@@ -44,7 +44,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -52,7 +52,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -35,7 +35,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, STAKING' }} },
   unique_key = 'fact_stake_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, STAKING' }} },
   unique_key = 'fact_stake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, STAKING' }} },
   unique_key = 'fact_stake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -25,18 +25,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__stake_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -66,3 +54,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -51,7 +51,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -59,7 +59,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_stake_events.sql
+++ b/models/gold/defi/defi__fact_stake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, STAKING' }} },
   unique_key = 'fact_stake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -39,7 +39,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_streamling_swap_details_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_streamling_swap_details_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -60,7 +60,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -68,7 +68,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_streamling_swap_details_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_streamling_swap_details_events.sql
+++ b/models/gold/defi/defi__fact_streamling_swap_details_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_streamling_swap_details_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -29,18 +29,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__streamling_swap_details_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -75,3 +63,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swaps_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swaps_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -52,7 +52,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -84,7 +84,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
 {% if is_incremental() %}
@@ -92,7 +92,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swaps_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swaps_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -42,18 +42,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__swaps') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -99,3 +87,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swap_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swap_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swap_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM, SWAPS' }} },
   unique_key = 'fact_swap_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -33,18 +33,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__swap_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -81,3 +69,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -66,7 +66,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -74,7 +74,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_swaps_events.sql
+++ b/models/gold/defi/defi__fact_swaps_events.sql
@@ -43,7 +43,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_switch_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -21,18 +21,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__switch_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -58,3 +46,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -43,7 +43,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -51,7 +51,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_switch_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_switch_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -31,7 +31,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_switch_events.sql
+++ b/models/gold/defi/defi__fact_switch_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_switch_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_block_rewards_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__total_block_rewards') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -52,3 +40,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_block_rewards_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_block_rewards_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -37,7 +37,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
 {% if is_incremental() %}
@@ -45,7 +45,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_total_block_rewards.sql
+++ b/models/gold/defi/defi__fact_total_block_rewards.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_block_rewards_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_total_value_locked.sql
+++ b/models/gold/defi/defi__fact_total_value_locked.sql
@@ -22,7 +22,7 @@ WHERE
   DAY >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_total_value_locked.sql
+++ b/models/gold/defi/defi__fact_total_value_locked.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_value_locked_id',
-  incremental_strategy = 'merge'
+  incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH base AS (

--- a/models/gold/defi/defi__fact_total_value_locked.sql
+++ b/models/gold/defi/defi__fact_total_value_locked.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_value_locked_id',
-  incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  incremental_strategy = 'merge'
 ) }}
 
 WITH base AS (

--- a/models/gold/defi/defi__fact_total_value_locked.sql
+++ b/models/gold/defi/defi__fact_total_value_locked.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_total_value_locked_id',
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   incremental_strategy = 'merge'
 ) }}
 

--- a/models/gold/defi/defi__fact_total_value_locked.sql
+++ b/models/gold/defi/defi__fact_total_value_locked.sql
@@ -25,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -29,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR event_id IN (
     SELECT
       event_id

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -42,7 +42,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -50,7 +50,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -20,26 +20,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__trade_account_deposit_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR event_id IN (
-    SELECT
-      event_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -65,3 +45,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR event_id IN (
+    SELECT
+      event_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_trade_account_deposit_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_deposit_events.sql
@@ -30,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR event_id IN (
     SELECT
       event_id

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -29,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
   OR event_id IN (
     SELECT
       event_id

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -42,7 +42,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -50,7 +50,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -20,26 +20,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__trade_account_withdraw_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR event_id IN (
-    SELECT
-      event_id
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -65,3 +45,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR event_id IN (
+    SELECT
+      event_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -30,7 +30,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR event_id IN (
     SELECT
       event_id

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_trade_account_withdraw_events.sql
@@ -3,7 +3,6 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'event_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -41,7 +41,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_unstake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE'],
   enabled = false
 ) }}

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_unstake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE'],
   enabled = false
 ) }}
@@ -30,19 +30,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__unstake_events') }}
-    e
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -77,3 +64,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_unstake_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE'],
   enabled = false
 ) }}

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_unstake_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE'],
   enabled = false
 ) }}

--- a/models/gold/defi/defi__fact_unstake_events.sql
+++ b/models/gold/defi/defi__fact_unstake_events.sql
@@ -61,7 +61,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -69,7 +69,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_update_node_account_status_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -36,7 +36,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -44,7 +44,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_update_node_account_status_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_update_node_account_status_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_update_node_account_status_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -17,18 +17,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__update_node_account_status_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -51,3 +39,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_update_node_account_status_events.sql
+++ b/models/gold/defi/defi__fact_update_node_account_status_events.sql
@@ -27,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_upgrades.sql
+++ b/models/gold/defi/defi__fact_upgrades.sql
@@ -47,15 +47,15 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id
 {% if is_incremental() %}
 WHERE
-  dim_block_id >= (
+  b.block_timestamp >= (
     SELECT
       MAX(
-        dim_block_id
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/defi/defi__fact_upgrades.sql
+++ b/models/gold/defi/defi__fact_upgrades.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_upgrades_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_upgrades.sql
+++ b/models/gold/defi/defi__fact_upgrades.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_upgrades_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_upgrades.sql
+++ b/models/gold/defi/defi__fact_upgrades.sql
@@ -33,7 +33,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_upgrades.sql
+++ b/models/gold/defi/defi__fact_upgrades.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_upgrades_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_withdraw_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_withdraw_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -29,20 +29,7 @@ WITH base AS (
     _TX_TYPE,
     _INSERTED_TIMESTAMP
   FROM
-    {{ ref('silver__withdraw_events') }}
-    e
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
+    {{ ref('silver__withdraw_events') }} e
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -78,3 +65,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -41,7 +41,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_withdraw_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_withdraw_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/defi/defi__fact_withdraw_events.sql
+++ b/models/gold/defi/defi__fact_withdraw_events.sql
@@ -62,7 +62,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -70,7 +70,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_new_node_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_new_node_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -16,26 +16,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__new_node_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-  OR node_address IN (
-    SELECT
-      node_address
-    FROM
-      {{ this }}
-    WHERE
-      dim_block_id = '-1'
-  )
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -56,3 +36,22 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR node_address IN (
+    SELECT
+      node_address
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_new_node_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_new_node_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -33,7 +33,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -41,7 +41,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_new_node_events.sql
+++ b/models/gold/gov/gov__fact_new_node_events.sql
@@ -26,7 +26,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
   OR node_address IN (
     SELECT
       node_address

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_ip_address_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_ip_address_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_ip_address_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -17,18 +17,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__set_ip_address_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -50,3 +38,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -27,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -35,7 +35,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -43,7 +43,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_set_ip_address_events.sql
+++ b/models/gold/gov/gov__fact_set_ip_address_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_ip_address_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_node_keys_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_node_keys_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -19,18 +19,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__set_node_keys_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -54,3 +42,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -39,7 +39,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -47,7 +47,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_node_keys_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_node_keys_events.sql
+++ b/models/gold/gov/gov__fact_set_node_keys_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_node_keys_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_version_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -17,18 +17,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__set_version_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -50,3 +38,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_set_version_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -27,7 +27,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_set_version_events.sql
+++ b/models/gold/gov/gov__fact_set_version_events.sql
@@ -35,7 +35,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -43,7 +43,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_amounts_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__slash_amounts') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -52,3 +40,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -37,7 +37,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -45,7 +45,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_amounts_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_amounts_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_slash_amounts.sql
+++ b/models/gold/gov/gov__fact_slash_amounts.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_amounts_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_points_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _INSERTED_TIMESTAMP
   FROM
     {{ ref('silver__slash_points') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -52,3 +40,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -37,7 +37,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -45,7 +45,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_points_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_points_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_slash_points.sql
+++ b/models/gold/gov/gov__fact_slash_points.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_slash_points_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_validator_request_leave_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_validator_request_leave_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_validator_request_leave_events_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -37,7 +37,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -45,7 +45,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/gov/gov__fact_validator_request_leave_events.sql
+++ b/models/gold/gov/gov__fact_validator_request_leave_events.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_validator_request_leave_events_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -18,18 +18,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__validator_request_leave_events') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -52,3 +40,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/price/price__fact_prices.sql
+++ b/models/gold/price/price__fact_prices.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'FACT_PRICES_ID',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST. block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/price/price__fact_prices.sql
+++ b/models/gold/price/price__fact_prices.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'FACT_PRICES_ID',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST. block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -23,7 +23,14 @@ WITH base AS (
 
 {% if is_incremental() %}
 WHERE
-  block_timestamp :: DATE >= CURRENT_DATE -2
+  block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/gold/price/price__fact_prices.sql
+++ b/models/gold/price/price__fact_prices.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'FACT_PRICES_ID',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -22,7 +23,7 @@ WITH base AS (
 
 {% if is_incremental() %}
 WHERE
-  block_timestamp :: DATE >= CURRENT_DATE -5
+  block_timestamp :: DATE >= CURRENT_DATE -2
 {% endif %}
 )
 SELECT

--- a/models/gold/price/price__fact_prices.sql
+++ b/models/gold/price/price__fact_prices.sql
@@ -26,7 +26,7 @@ WHERE
   block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
@@ -52,6 +52,6 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_id = b.block_id

--- a/models/gold/price/price__fact_prices.sql
+++ b/models/gold/price/price__fact_prices.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'FACT_PRICES_ID',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -3,6 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rune_price_id',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -24,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}
 )
 SELECT

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rune_price_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -15,18 +15,6 @@ WITH base AS (
     _inserted_timestamp
   FROM
     {{ ref('silver__rune_price') }}
-
-{% if is_incremental() %}
-WHERE
-  _inserted_timestamp >= (
-    SELECT
-      MAX(
-        _inserted_timestamp
-      )
-    FROM
-      {{ this }}
-  ) 
-{% endif %}
 )
 SELECT
   {{ dbt_utils.generate_surrogate_key(
@@ -47,3 +35,14 @@ FROM
   LEFT JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rune_price_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -32,7 +32,7 @@ SELECT
   SYSDATE() AS modified_timestamp
 FROM
   base A
-  LEFT JOIN {{ ref('core__dim_block') }}
+  JOIN {{ ref('core__dim_block') }}
   b
   ON A.block_timestamp = b.timestamp
 {% if is_incremental() %}
@@ -40,7 +40,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -3,7 +3,7 @@
   meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
   unique_key = 'fact_rune_price_id',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/gold/price/price__fact_rune_price.sql
+++ b/models/gold/price/price__fact_rune_price.sql
@@ -25,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/silver/prices/silver__complete_native_asset_metadata.sql
+++ b/models/silver/prices/silver__complete_native_asset_metadata.sql
@@ -29,7 +29,7 @@ WHERE
     modified_timestamp >= (
         SELECT
             MAX(
-                modified_timestamp
+                modified_timestamp - INTERVAL '1 HOUR'
             )
         FROM
             {{ this }}

--- a/models/silver/prices/silver__complete_native_prices.sql
+++ b/models/silver/prices/silver__complete_native_prices.sql
@@ -32,7 +32,7 @@ WHERE
     modified_timestamp >= (
         SELECT
             MAX(
-                modified_timestamp
+                modified_timestamp - INTERVAL '1 HOUR'
             )
         FROM
             {{ this }}

--- a/models/silver/prices/silver__complete_provider_asset_metadata.sql
+++ b/models/silver/prices/silver__complete_provider_asset_metadata.sql
@@ -29,7 +29,7 @@ WHERE
     modified_timestamp >= (
         SELECT
             MAX(
-                modified_timestamp
+                modified_timestamp - INTERVAL '1 HOUR'
             )
         FROM
             {{ this }}

--- a/models/silver/prices/silver__complete_provider_prices.sql
+++ b/models/silver/prices/silver__complete_provider_prices.sql
@@ -33,7 +33,7 @@ WHERE
     p.modified_timestamp >= (
         SELECT
             MAX(
-                modified_timestamp
+                modified_timestamp - INTERVAL '1 HOUR'
             )
         FROM
             {{ this }}

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -25,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   block_timestamp
@@ -54,7 +54,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   block_timestamp
@@ -109,7 +109,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   1
@@ -135,7 +135,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY
@@ -161,7 +161,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = 'day',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['_inserted_timestamp::DATE'],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = 'day',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -20,7 +20,7 @@ WHERE
   ) :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -49,7 +49,7 @@ WHERE
   ) :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -104,7 +104,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -130,7 +130,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -156,7 +156,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -3,7 +3,7 @@
   unique_key = 'day',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__block_rewards.sql
+++ b/models/silver/silver__block_rewards.sql
@@ -3,7 +3,7 @@
   unique_key = 'day',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__daily_earnings.sql
+++ b/models/silver/silver__daily_earnings.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = 'day',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_earnings.sql
+++ b/models/silver/silver__daily_earnings.sql
@@ -3,7 +3,7 @@
   unique_key = 'day',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_earnings.sql
+++ b/models/silver/silver__daily_earnings.sql
@@ -28,7 +28,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY
@@ -53,7 +53,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -106,5 +106,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}

--- a/models/silver/silver__daily_earnings.sql
+++ b/models/silver/silver__daily_earnings.sql
@@ -3,7 +3,7 @@
   unique_key = 'day',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_earnings.sql
+++ b/models/silver/silver__daily_earnings.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = 'day',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['_inserted_timestamp::DATE'],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -1,7 +1,8 @@
 {{ config(
   materialized = 'incremental',
   unique_key = "_unique_key",
-  incremental_strategy = 'merge'
+  incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH daily_rune_price AS (

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  cluster_by = ['block_timestamp::DATE'],
   incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -22,7 +22,7 @@ WHERE
   block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -54,7 +54,7 @@ WHERE
   pbf.day >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -169,7 +169,7 @@ WHERE
   pbs.day >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -3, current_date)]
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= dateadd(hour, -48, current_timestamp)]
 ) }}
 
 WITH daily_rune_price AS (

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= dateadd(hour, -48, current_timestamp)]
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 
 WITH daily_rune_price AS (

--- a/models/silver/silver__daily_pool_stats.sql
+++ b/models/silver/silver__daily_pool_stats.sql
@@ -25,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   pool_name,
@@ -57,7 +57,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT
@@ -172,5 +172,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -22,7 +22,7 @@ WHERE
   block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -47,7 +47,7 @@ WHERE
   block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "day",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= dateadd(hour, -48, current_timestamp)]  
+  incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "day",
   incremental_strategy = 'merge',
+  cluster_by = ['day'],
   incremental_predicates = ['DBT_INTERNAL_DEST.day >= (select min(day) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "day",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -3, current_date)]  
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= dateadd(hour, -48, current_timestamp)]  
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -1,7 +1,8 @@
 {{ config(
   materialized = 'incremental',
   unique_key = "day",
-  incremental_strategy = 'merge'
+  incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -2, current_date)]  
 ) }}
 
 WITH max_daily_block AS (

--- a/models/silver/silver__daily_tvl.sql
+++ b/models/silver/silver__daily_tvl.sql
@@ -25,7 +25,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY
@@ -50,7 +50,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -33,7 +33,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 ),
 unstakes AS (
@@ -63,7 +63,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -32,7 +32,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}
 ),
 unstakes AS (
@@ -62,7 +62,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}
 )
 SELECT

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -100,7 +100,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
@@ -172,7 +172,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -3,7 +3,7 @@
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')']
 ) }}
 
 WITH stakes AS (

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['_inserted_timestamp::DATE'],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH stakes AS (

--- a/models/silver/silver__liquidity_actions.sql
+++ b/models/silver/silver__liquidity_actions.sql
@@ -3,7 +3,7 @@
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
   cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)]
 ) }}
 
 WITH stakes AS (

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -37,7 +37,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],   
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -41,5 +42,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 SELECT
@@ -35,10 +34,10 @@ FROM
 
 {% if is_incremental() %}
 WHERE
-  bpd._inserted_timestamp >= (
+  b.block_timestamp >= (
     SELECT
       MAX(
-        _inserted_timestamp
+        block_timestamp
       )
     FROM
       {{ this }}

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -41,5 +42,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}

--- a/models/silver/silver__pool_block_balances.sql
+++ b/models/silver/silver__pool_block_balances.sql
@@ -2,7 +2,6 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],   
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__pool_block_fees.sql
+++ b/models/silver/silver__pool_block_fees.sql
@@ -1,7 +1,8 @@
 {{ config(
   materialized = 'incremental',
   unique_key = "_unique_key",
-  incremental_strategy = 'merge'
+  incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__pool_block_fees.sql
+++ b/models/silver/silver__pool_block_fees.sql
@@ -27,7 +27,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -55,7 +55,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -83,7 +83,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -118,7 +118,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -154,7 +154,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/silver/silver__pool_block_fees.sql
+++ b/models/silver/silver__pool_block_fees.sql
@@ -1,7 +1,9 @@
 {{ config(
   materialized = 'incremental',
   unique_key = "_unique_key",
-  incremental_strategy = 'merge'
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.DAY >= (select min(DAY) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  cluster_by = ['day']
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__pool_block_fees.sql
+++ b/models/silver/silver__pool_block_fees.sql
@@ -1,8 +1,7 @@
 {{ config(
   materialized = 'incremental',
   unique_key = "_unique_key",
-  incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  incremental_strategy = 'merge'
 ) }}
 
 WITH all_block_id AS (

--- a/models/silver/silver__pool_block_fees.sql
+++ b/models/silver/silver__pool_block_fees.sql
@@ -29,7 +29,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -57,7 +57,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -85,7 +85,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -120,7 +120,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 GROUP BY
@@ -156,7 +156,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 GROUP BY

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -41,7 +41,7 @@ WITH pool_depth AS (
 AND b.block_timestamp :: DATE >= (
   SELECT
     MAX(
-      DAY
+      DAY - INTERVAL '2 DAYS' --counteract clock skew
     )
   FROM
     {{ this }}
@@ -78,7 +78,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -109,7 +109,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -141,7 +141,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -178,7 +178,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -226,7 +226,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -277,7 +277,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -309,7 +309,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -339,7 +339,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -367,7 +367,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -396,7 +396,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -427,7 +427,7 @@ stake_umc AS (
 AND b.block_timestamp :: DATE >= (
   SELECT
     MAX(
-      DAY
+      DAY - INTERVAL '2 DAYS' --counteract clock skew
     )
   FROM
     {{ this }}
@@ -458,7 +458,7 @@ WHERE
 AND b.block_timestamp :: DATE >= (
   SELECT
     MAX(
-      DAY
+      DAY - INTERVAL '2 DAYS' --counteract clock skew
     )
   FROM
     {{ this }}

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -44,7 +44,7 @@ AND b.block_timestamp :: DATE >= (
     )
   FROM
     {{ this }}
-) - INTERVAL '48 HOURS'
+) 
 {% endif %}
 )
 WHERE
@@ -81,7 +81,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 WHERE
@@ -112,7 +112,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -144,7 +144,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -181,7 +181,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 GROUP BY
@@ -229,7 +229,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 GROUP BY
@@ -280,7 +280,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 GROUP BY
@@ -312,7 +312,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   pool_name,
@@ -342,7 +342,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   pool_name,
@@ -370,7 +370,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   pool_name,
@@ -399,7 +399,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   from_address,
@@ -430,7 +430,7 @@ AND b.block_timestamp :: DATE >= (
     )
   FROM
     {{ this }}
-) - INTERVAL '48 HOURS'
+) 
 {% endif %}
 GROUP BY
   rune_address,
@@ -461,7 +461,7 @@ AND b.block_timestamp :: DATE >= (
     )
   FROM
     {{ this }}
-) - INTERVAL '48 HOURS'
+) 
 {% endif %}
 GROUP BY
   asset_address,

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.DAY >= (select min(DAY) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['day']
 ) }}
 

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  cluster_by = ['day']
+  cluster_by = ['day'],
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH pool_depth AS (

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  cluster_by = ['day'],
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -3, current_date)]
+  cluster_by = ['day']
 ) }}
 
 WITH pool_depth AS (

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  cluster_by = ['block_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE'],
+  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= datediff(day, -7, current_date)]
 ) }}
 -- block level prices by pool
 -- step 1 what is the USD pool with the highest balance (aka deepest pool)

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -22,7 +22,7 @@ WITH blocks AS (
 
 {% if is_incremental() %}
 WHERE
-  b.block_timestamp :: DATE >= CURRENT_DATE -5
+  b.block_timestamp :: DATE >= CURRENT_DATE -2
 {% endif %}
 ),
 price AS (
@@ -38,7 +38,7 @@ price AS (
 
 {% if is_incremental() %}
 WHERE
-  b.block_timestamp :: DATE >= CURRENT_DATE -7
+  b.block_timestamp :: DATE >= CURRENT_DATE -2
 {% endif %}
 ) -- step 3 calculate the prices of assets by pool, in terms of tokens per tokens
 -- and in USD for both tokens

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  cluster_by = ['block_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST.block_timestamp" >= datediff(day, -7, current_date)]
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 -- block level prices by pool
 -- step 1 what is the USD pool with the highest balance (aka deepest pool)
@@ -23,7 +22,7 @@ WITH blocks AS (
 
 {% if is_incremental() %}
 WHERE
-  b.block_timestamp :: DATE >= CURRENT_DATE -7
+  b.block_timestamp :: DATE >= CURRENT_DATE -5
 {% endif %}
 ),
 price AS (

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -26,7 +26,7 @@ WHERE
  b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}
@@ -49,7 +49,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -2,7 +2,8 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['_inserted_timestamp::DATE'],
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)]
 ) }}
 
 WITH swaps AS (

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -53,7 +54,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 )
 SELECT

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE'],
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)]
+  cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
 WITH swaps AS (

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -53,7 +53,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}
 )
 SELECT

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -49,7 +49,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__swaps.sql
+++ b/models/silver/silver__swaps.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH swaps AS (
@@ -47,10 +46,10 @@ WITH swaps AS (
 
 {% if is_incremental() %}
 WHERE
-  A._INSERTED_TIMESTAMP :: DATE >= (
+  b.block_timestamp >= (
     SELECT
       MAX(
-        _INSERTED_TIMESTAMP
+        block_timestamp
       )
     FROM
       {{ this }}

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -45,7 +45,7 @@ WHERE
     b.block_timestamp >= (
       SELECT
         MAX(
-          block_timestamp
+          block_timestamp - INTERVAL '1 HOUR'
         )
       FROM
         {{ this }}
@@ -98,7 +98,7 @@ WHERE
     b.block_timestamp :: DATE >= (
       SELECT
         MAX(
-          block_timestamp
+          block_timestamp - INTERVAL '1 HOUR'
         )
       FROM
         {{ this }}

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -2,7 +2,6 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -49,7 +50,7 @@ WHERE
         )
       FROM
         {{ this }}
-    ) - INTERVAL '48 HOURS'
+    ) 
     OR concat_ws(
       '-',
       b.height,
@@ -102,7 +103,7 @@ WHERE
         )
       FROM
         {{ this }}
-    ) - INTERVAL '48 HOURS'
+    ) 
     OR concat_ws(
       '-',
       b.height,

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -49,7 +49,7 @@ WHERE
         )
       FROM
         {{ this }}
-    ) - INTERVAL '4 HOURS'
+    ) - INTERVAL '48 HOURS'
     OR concat_ws(
       '-',
       b.height,
@@ -102,7 +102,7 @@ WHERE
         )
       FROM
         {{ this }}
-    ) - INTERVAL '4 HOURS'
+    ) - INTERVAL '48 HOURS'
     OR concat_ws(
       '-',
       b.height,

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH block_prices AS (
@@ -43,10 +42,10 @@ fin AS (
 {% if is_incremental() %}
 WHERE
   (
-    ree._INSERTED_TIMESTAMP :: DATE >= (
+    b.block_timestamp >= (
       SELECT
         MAX(
-          _INSERTED_TIMESTAMP
+          block_timestamp
         )
       FROM
         {{ this }}
@@ -96,10 +95,10 @@ FROM
 {% if is_incremental() %}
 WHERE
   (
-    re._INSERTED_TIMESTAMP :: DATE >= (
+    b.block_timestamp :: DATE >= (
       SELECT
         MAX(
-          _INSERTED_TIMESTAMP
+          block_timestamp
         )
       FROM
         {{ this }}

--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__total_value_locked.sql
+++ b/models/silver/silver__total_value_locked.sql
@@ -31,7 +31,7 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 GROUP BY
   DAY,
@@ -91,7 +91,7 @@ AND
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}
 ),
 total_pool_depth_max AS (

--- a/models/silver/silver__total_value_locked.sql
+++ b/models/silver/silver__total_value_locked.sql
@@ -27,7 +27,7 @@ WHERE
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}
@@ -87,7 +87,7 @@ AND
   b.block_timestamp :: DATE >= (
     SELECT
       MAX(
-        DAY
+        DAY - INTERVAL '2 DAYS' --counteract clock skew
       )
     FROM
       {{ this }}

--- a/models/silver/silver__total_value_locked.sql
+++ b/models/silver/silver__total_value_locked.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "day",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -2, current_date)],
   cluster_by = ['day']
 ) }}
 

--- a/models/silver/silver__total_value_locked.sql
+++ b/models/silver/silver__total_value_locked.sql
@@ -2,7 +2,6 @@
   materialized = 'incremental',
   unique_key = "day",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST.day" >= datediff(day, -3, current_date)],
   cluster_by = ['day']
 ) }}
 

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -2,7 +2,6 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)],
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -46,7 +46,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
+  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= dateadd(hour, -48, current_timestamp)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -50,5 +51,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)],
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -2,8 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ['DBT_INTERNAL_DEST._inserted_timestamp >= (select min(_inserted_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH block_prices AS (
@@ -44,10 +43,10 @@ FROM
 
 {% if is_incremental() %}
 WHERE
-  se._INSERTED_TIMESTAMP :: DATE >= (
+  b.block_timestamp >= (
     SELECT
       MAX(
-        _INSERTED_TIMESTAMP
+        block_timestamp
       )
     FROM
       {{ this }}

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -50,5 +50,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}

--- a/models/silver/silver__upgrades.sql
+++ b/models/silver/silver__upgrades.sql
@@ -65,5 +65,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '48 HOURS'
+  ) 
 {% endif %}

--- a/models/silver/silver__upgrades.sql
+++ b/models/silver/silver__upgrades.sql
@@ -61,7 +61,7 @@ WHERE
   b.block_timestamp >= (
     SELECT
       MAX(
-        block_timestamp
+        block_timestamp - INTERVAL '1 HOUR'
       )
     FROM
       {{ this }}

--- a/models/silver/silver__upgrades.sql
+++ b/models/silver/silver__upgrades.sql
@@ -2,7 +2,6 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -3, current_date)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 

--- a/models/silver/silver__upgrades.sql
+++ b/models/silver/silver__upgrades.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
+  incremental_predicates = ["DBT_INTERNAL_DEST._inserted_timestamp" >= datediff(day, -2, current_date)], 
   cluster_by = ['_inserted_timestamp::DATE']
 ) }}
 
@@ -65,5 +66,5 @@ WHERE
       )
     FROM
       {{ this }}
-  ) - INTERVAL '4 HOURS'
+  ) - INTERVAL '48 HOURS'
 {% endif %}

--- a/models/silver/silver__upgrades.sql
+++ b/models/silver/silver__upgrades.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  cluster_by = ['_inserted_timestamp::DATE']
+  cluster_by = ['block_timestamp::DATE']
 ) }}
 
 WITH block_prices AS (
@@ -58,10 +58,10 @@ FROM
 
 {% if is_incremental() %}
 WHERE
-  se._inserted_timestamp >= (
+  b.block_timestamp >= (
     SELECT
       MAX(
-        _inserted_timestamp
+        block_timestamp
       )
     FROM
       {{ this }}


### PR DESCRIPTION
## Summary
This PR modifies incremental filter logic and the merge strategy for many silver and gold models. If merged, incremental data is retrieved from the previous 48 hours instead of 4. A 48 hour lookback is very conservative, but accounts for any datetime discrepancies between UTC and SYSDATE. 

Also, [incremental_predicate](https://docs.getdbt.com/docs/build/incremental-strategy#about-incremental_predicates) has been added to most gold model configs to reduce merge load.

## Risks and benefits
While the incremental filter is not necessary for this DAG to function properly, it makes more efficient use of resources by scanning only recent chain history at each incremental run. **The risk tradeoff is that gold models will be missing data should incremental jobs fail for 48 straight hours.** This can be prevented by subscribing to alerts in `#alerts-ibc`.

## Data QA

### Confirming row counts
These changes were evaluated using:
1. A dbt command (run locally in dev) immedately after a [completed prod workflow](https://github.com/FlipsideCrypto/thorchain-models/actions/workflows/dbt_run_incremental.yml): `dbt run -s core__fact_transfers defi__fact_swaps defi__fact_liquidity_actions defi__fact_total_block_rewards`
2.  Subsequently, the following query:
```sql
with prod as (
    select 
        table_name
        , last_altered 
        , row_count
    from thorchain.information_schema.tables 
    where table_schema in ('CORE', 'DEFI', 'GOV', 'PRICE')
),
dev as (
    select 
        table_name
        , last_altered 
        , row_count
    from thorchain_dev.information_schema.tables 
    where table_schema in ('CORE', 'DEFI', 'GOV', 'PRICE')
)
select 
    prod.table_name,
    prod.last_altered as last_refresh_prod,
    dev.last_altered as last_refresh_dev,
    timestampdiff( -- how many minutes prod is behind
        'MINUTE'
        , prod.last_altered
        , dev.last_altered
    ) as prod_lag_minutes,
    prod.row_count as row_ct_prod,
    dev.row_count as row_ct_dev,
    (dev.row_count - prod.row_count) as row_diff_from_prod
from prod
left join dev on prod.table_name = dev.table_name
order by 7;
```

The result shows that there is no missing data, indicated by no large negative row counts in the `row_diff_from_prod` column. 

### Confirming data accuracy
#### BTC Prices
This query confirms that incremental logic doesn't break price data:
```sql
-- gut check
with prod as (
    select 
        split_part(pool_name, '-', 1) as token
        , date_trunc('hour', block_timestamp) as hour
        , max(asset_usd) as maxprice
        , avg(asset_usd) as avgprice
    from thorchain.price.fact_prices
    where 
        block_timestamp >= current_date - 1 
        and token = 'BTC.BTC'
    group by all
),
dev as (
    select 
        split_part(pool_name, '-', 1) as token
        , date_trunc('hour', block_timestamp) as hour
        , max(asset_usd) as maxprice
        , avg(asset_usd) as avgprice
    from thorchain_dev.price.fact_prices
    where 
        block_timestamp >= current_date - 1
        and token = 'BTC.BTC'
    group by all
)
select 
    prod.token
    , prod.hour
    , round(prod.maxprice, 0) as maxprice_prod
    , round(dev.maxprice, 0) as maxprice_dev
    , round(prod.avgprice, 0) as avgprice_prod
    , round(dev.avgprice, 0) as avgprice_dev 
from prod 
left join dev 
    on prod.token = dev.token 
    and prod.hour = dev.hour 
order by hour desc;
```

#### Swap volume
This query (taken from a Rayyyk dashboard on Flipside) confirms that incremental logic doesn't break swap counts:
```sql
with prod as (
    select 
        date_trunc('hour', block_timestamp) as hour
        , count(fact_swaps_id) as vol
    from thorchain.defi.fact_swaps
    where block_timestamp >= '2024-07-15'
    group by 1
),
dev as (
    select 
        date_trunc('hour', block_timestamp) as hour
        , count(fact_swaps_id) as vol
    from thorchain_dev.defi.fact_swaps
    where block_timestamp >= '2024-07-15'
    group by 1
)
select 
    prod.hour
    , prod.vol
    , dev.vol vol_dev 
from prod 
left join dev on prod.hour = dev.hour 
order by 1 desc;
```

## Other notes
Midgard and Hevo load data in UTC time, whereas Snowflake’s default timezone is Los Angeles (UTC-7).
- Midgard [docs](https://gitlab.com/thorchain/midgard/-/blob/develop/internal/db/inttime.go#L15)
- Hevo [docs](https://docs.hevodata.com/introduction/core-concepts/data-transformation/)
- Snowflake [docs](https://docs.snowflake.com/en/sql-reference/parameters#timezone)
