### PR TITLE
Upgrade to Midgard 2.25.1

### DIFF
--- a/models/bronze/bronze__failed_deposit_messages.sql
+++ b/models/bronze/bronze__failed_deposit_messages.sql
@@ -1,0 +1,23 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+  tx_id,
+  code,
+  memo,
+  asset,
+  amount_e8,
+  from_addr,
+  reason,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT,
+  __HEVO__SCHEMA_NAME
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_failed_deposit_messages'
+  ) }}

--- a/models/descriptions/__overview__.md
+++ b/models/descriptions/__overview__.md
@@ -45,6 +45,7 @@ There is more information on how to use dbt docs in the last section of this doc
 - [defi.fact_daily_pool_stats](#!/model/model.thorchain_models.defi__fact_daily_pool_stats)
 - [defi.fact_daily_tvl](#!/model/model.thorchain_models.defi__fact_daily_tvl)
 - [defi.fact_errata_events](#!/model/model.thorchain_models.defi__fact_errata_events)
+- [defi.fact_failed_deposit_messages](#!/model/model.thorchain_models.defi__fact_failed_deposit_messages)
 - [defi.fact_fee_events](#!/model/model.thorchain_models.defi__fact_fee_events)
 - [defi.fact_gas_events](#!/model/model.thorchain_models.defi__fact_gas_events)
 - [defi.fact_inactive_vault_events](#!/model/model.thorchain_models.defi__fact_inactive_vault_events)

--- a/models/gold/core/core__dim_midgard.sql
+++ b/models/gold/core/core__dim_midgard.sql
@@ -3,4 +3,4 @@
 ) }}
 
 SELECT
-    '2.24.2' AS midgard_version
+    '2.25.1' AS midgard_version

--- a/models/gold/defi/defi__fact_failed_deposit_messages.sql
+++ b/models/gold/defi/defi__fact_failed_deposit_messages.sql
@@ -1,0 +1,70 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_failed_deposit_messages_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'], 
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    amount_e8,
+    asset,
+    from_address,
+    memo,
+    code,
+    reason,
+    tx_id,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__failed_deposit_messages') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.block_timestamp']
+  ) }} AS fact_failed_deposit_messages_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  amount_e8,
+  asset,
+  from_address,
+  memo,
+  code,
+  reason,
+  tx_id,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+  OR event_id IN (
+    SELECT
+      event_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_failed_deposit_messages.yml
+++ b/models/gold/defi/defi__fact_failed_deposit_messages.yml
@@ -1,0 +1,51 @@
+version: 2
+models:
+  - name: defi__fact_failed_deposit_messages
+    description: "Fact table containing failed deposit messages"
+    columns:
+      - name: FACT_FAILED_DEPOSIT_MESSAGES_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - not_null
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: AMOUNT_E8
+        description: "The amount of the failed deposit in E8 notation"
+        tests:
+          - not_null
+      - name: ASSET
+        description: "{{ doc('asset') }}"
+        tests:
+          - not_null
+      - name: FROM_ADDRESS
+        description: "{{ doc('from_address') }}"
+      - name: MEMO
+        description: "{{ doc('memo') }}"
+      - name: CODE
+        description: "Error code associated with the failed deposit"
+      - name: REASON
+        description: "Detailed reason for the failed deposit"
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+      - name: EVENT_ID
+        description: "Unique identifier for the failed deposit event"
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_FAILED_DEPOSIT_MESSAGES_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/silver/silver__failed_deposit_messages.sql
+++ b/models/silver/silver__failed_deposit_messages.sql
@@ -21,3 +21,6 @@ FROM
   {{ ref(
     'bronze__failed_deposit_messages'
   ) }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1

--- a/models/silver/silver__failed_deposit_messages.sql
+++ b/models/silver/silver__failed_deposit_messages.sql
@@ -1,0 +1,23 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+  amount_e8,
+  asset,
+  from_addr as from_address,
+  memo,
+  code,
+  reason,
+  tx_id,
+  event_id,
+  block_timestamp,
+  DATEADD(
+    ms,
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _INSERTED_TIMESTAMP
+FROM
+  {{ ref(
+    'bronze__failed_deposit_messages'
+  ) }}

--- a/models/silver/silver__failed_deposit_messages.yml
+++ b/models/silver/silver__failed_deposit_messages.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: silver__failed_deposit_messages
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+    columns:
+      - name: AMOUNT_E8
+        tests:
+          - not_null
+      - name: ASSET
+        tests:
+          - not_null
+      - name: FROM_ADDRESS
+        tests:
+          - not_null
+      - name: MEMO
+      - name: CODE
+      - name: REASON
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: thorchain_midgard
     database: HEVO
-    schema: THORCHAIN_MIDGARD_2_24_2_new
+    schema: THORCHAIN_MIDGARD_2_25_1
     tables:
       - name: midgard_active_vault_events
       - name: midgard_add_events
@@ -14,6 +14,7 @@ sources:
       - name: bond_events_pk_count
       - name: midgard_constants
       - name: midgard_errata_events
+      - name: midgard_failed_deposit_messages
       - name: midgard_fee_events
       - name: fee_events_pk_count
       - name: midgard_gas_events


### PR DESCRIPTION
Changes:
* Swapped Hevo schemas in `sources.yml` from 2.24.2 to 2.25.1.
* Updated `dim_constants` with 2.25.1
* Added `failed_deposit_messages` lineage (bronze, silver, gold/defi)
* Updated overview docs