### PR TITLE
Upgrade to 2.28.1

### DIFF
--- a/models/gold/core/core__dim_midgard.sql
+++ b/models/gold/core/core__dim_midgard.sql
@@ -3,4 +3,4 @@
 ) }}
 
 SELECT
-    '2.26.0' AS midgard_version
+    '2.28.1' AS midgard_version

--- a/models/silver/silver__pool_block_statistics.sql
+++ b/models/silver/silver__pool_block_statistics.sql
@@ -488,6 +488,7 @@ joined AS (
     total_stake * synth_depth / ((asset_depth * 2) - synth_depth) AS synth_units,
     CASE
       WHEN total_stake = 0 THEN 0
+      WHEN depth_product < 0 THEN 0
       ELSE SQRT(depth_product) / (
         total_stake + synth_units
       )

--- a/models/silver/silver__rune_pool_deposit_events.sql
+++ b/models/silver/silver__rune_pool_deposit_events.sql
@@ -18,3 +18,9 @@ FROM
   {{ ref(
     'bronze__rune_pool_deposit_events'
   ) }}
+QUALIFY(
+  ROW_NUMBER() OVER (
+    PARTITION BY event_id
+    ORDER BY __HEVO__LOADED_AT DESC
+  ) = 1
+)

--- a/models/silver/silver__rune_pool_withdraw_events.sql
+++ b/models/silver/silver__rune_pool_withdraw_events.sql
@@ -22,3 +22,9 @@ FROM
   {{ ref(
     'bronze__rune_pool_withdraw_events'
   ) }}
+QUALIFY(
+  ROW_NUMBER() OVER (
+    PARTITION BY event_id
+    ORDER BY __HEVO__LOADED_AT DESC
+  ) = 1
+)

--- a/models/silver/silver__rune_price.sql
+++ b/models/silver/silver__rune_price.sql
@@ -17,6 +17,6 @@ FROM
 QUALIFY(
   ROW_NUMBER() OVER (
     PARTITION BY block_timestamp
-    ORDER BY __HEVO__LOADED_AT DESC
+    ORDER BY rune_price_e8 DESC
   ) = 1
 )

--- a/models/silver/silver__scheduled_outbound_events.sql
+++ b/models/silver/silver__scheduled_outbound_events.sql
@@ -26,3 +26,9 @@ SELECT
   ) AS _INSERTED_TIMESTAMP
 FROM
   {{ ref('bronze__scheduled_outbound_events') }}
+QUALIFY(
+  ROW_NUMBER() OVER (
+    PARTITION BY event_id
+    ORDER BY __HEVO__LOADED_AT DESC
+  ) = 1
+)

--- a/models/silver/silver__stake_events.sql
+++ b/models/silver/silver__stake_events.sql
@@ -22,6 +22,6 @@ SELECT
   ) AS _INSERTED_TIMESTAMP
 FROM
   {{ ref('bronze__stake_events') }}
-  qualify(ROW_NUMBER() over(PARTITION BY pool, rune_tx, asset_chain, stake_units, rune_addr, asset_tx, asset_addr, block_timestamp
+  qualify(ROW_NUMBER() over(PARTITION BY event_id, pool, rune_tx, asset_chain, stake_units, rune_addr, asset_tx, asset_addr, block_timestamp
 ORDER BY
   __HEVO__INGESTED_AT DESC)) = 1

--- a/models/silver/silver__stake_events.sql
+++ b/models/silver/silver__stake_events.sql
@@ -22,6 +22,6 @@ SELECT
   ) AS _INSERTED_TIMESTAMP
 FROM
   {{ ref('bronze__stake_events') }}
-  qualify(ROW_NUMBER() over(PARTITION BY event_id, pool, rune_tx, asset_chain, stake_units, rune_addr, asset_tx, asset_addr, block_timestamp
+  qualify(ROW_NUMBER() over(PARTITION BY pool, rune_tx, asset_chain, stake_units, rune_addr, asset_tx, asset_addr, block_timestamp
 ORDER BY
   __HEVO__INGESTED_AT DESC)) = 1

--- a/models/silver/silver__stake_events.yml
+++ b/models/silver/silver__stake_events.yml
@@ -12,6 +12,7 @@ models:
           - RUNE_TX_ID
           - RUNE_ADDRESS
           - BLOCK_TIMESTAMP
+          - EVENT_ID
     columns:
       - name: POOL_NAME
         tests:

--- a/models/silver/silver__swap_events.yml
+++ b/models/silver/silver__swap_events.yml
@@ -20,6 +20,7 @@ models:
             - LIQ_FEE_IN_RUNE_E8
             - _DIRECTION
             - BLOCK_TIMESTAMP
+            - EVENT_ID
     columns:
       - name: TX_ID
         tests:

--- a/models/silver/silver__update_node_account_status_events.yml
+++ b/models/silver/silver__update_node_account_status_events.yml
@@ -8,6 +8,7 @@ models:
             - CURRENT_STATUS
             - FORMER_STATUS
             - BLOCK_TIMESTAMP
+            - EVENT_ID
     columns:
       - name: NODE_ADDRESS
         tests:

--- a/models/silver/silver__withdraw_events.yml
+++ b/models/silver/silver__withdraw_events.yml
@@ -12,6 +12,7 @@ models:
             - MEMO
             - POOL_NAME
             - BLOCK_TIMESTAMP
+            - EVENT_ID
     columns:
       - name: TX_ID
         tests:

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: thorchain_midgard
     database: HEVO
-    schema: THORCHAIN_MIDGARD_2_26_0
+    schema: THORCHAIN_MIDGARD_2_28_1
     tables:
       - name: midgard_active_vault_events
       - name: midgard_add_events


### PR DESCRIPTION
## What's changed
* The usual changes: constants for version number, the hevo schema in `sources.yml`
* Additional logic in `silver__pool_block_statistics.sql` to resolve edge cases where  `depth_product` is an extremely small negative decimal but not zero, e.g. `-4.10234E+28`. This was breaking the `SQRT()` calculation.
* A fix to `silver__rune_price.sql` that uses correct price data from v2.26.0. This introduces opinionated data to the database in that it does not use up-to-date Midgard data, but rather what we ingested in a previous version. WIthout it, we would likely break most curated models.
* Changes to a few tests so they don't fail for duplicate rows with otherwise unique `event_id`s. 
 
For example, note the unique event IDs here:
```sql
select * 
from thorchain_dev.silver.withdraw_events 
where from_address = 'thor16jg26p48ue58kjxsu5l5w0gx6qdlaxhxsnrjzu' 
and block_timestamp = '1662213810657441857';
```