### PR TITLE
upgrade to 2.29.0 (drab) and add affiliate_fee_events pipeline

### DIFF
--- a/models/bronze/bronze__affiliate_fee_events.sql
+++ b/models/bronze/bronze__affiliate_fee_events.sql
@@ -1,0 +1,24 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+  tx_id,
+  fee_amt,
+  gross_amt,
+  fee_bps,
+  memo,
+  asset,
+  rune_address,
+  thorname,
+  event_id,
+  block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_affiliate_fee_events'
+  ) }}

--- a/models/gold/core/core__dim_midgard.sql
+++ b/models/gold/core/core__dim_midgard.sql
@@ -3,4 +3,4 @@
 ) }}
 
 SELECT
-    '2.28.1' AS midgard_version
+    '2.29.0' AS midgard_version

--- a/models/gold/defi/defi__fact_affiliate_fee_events.sql
+++ b/models/gold/defi/defi__fact_affiliate_fee_events.sql
@@ -1,0 +1,72 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_affiliate_fee_events_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+  SELECT
+    tx_id,
+    fee_amt,
+    gross_amt,
+    fee_bps,
+    memo,
+    asset,
+    rune_address,
+    thorname,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__affiliate_fee_events') }}
+)
+
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id', 'a.block_timestamp']
+  ) }} AS fact_affiliate_fee_events_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  tx_id,
+  fee_amt,
+  gross_amt,
+  fee_bps,
+  memo,
+  asset,
+  rune_address,
+  thorname,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  )
+  OR tx_id IN (
+    SELECT
+      tx_id
+    FROM
+      {{ this }}
+    WHERE
+      dim_block_id = '-1'
+  )
+{% endif %}

--- a/models/gold/defi/defi__fact_affiliate_fee_events.yml
+++ b/models/gold/defi/defi__fact_affiliate_fee_events.yml
@@ -1,0 +1,67 @@
+version: 2
+models:
+  - name: defi__fact_affiliate_fee_events
+    description: "Fact table containing all affiliate fee events that occur in the Thorchain network"
+    columns:
+      - name: FACT_AFFILIATE_FEE_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: FEE_AMT
+        description: "The affiliate fee amount collected for this transaction"
+        tests:
+          - not_null
+      - name: GROSS_AMT
+        description: "The total transaction amount before fees"
+        tests:
+          - not_null
+      - name: FEE_BPS
+        description: "The fee basis points charged for this affiliate transaction"
+        tests:
+          - not_null
+      - name: MEMO
+        description: "{{ doc('memo') }}"
+        tests:
+          - not_null
+      - name: ASSET
+        description: "{{ doc('asset') }}"
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        description: "The RUNE address associated with the affiliate"
+        tests:
+          - not_null
+      - name: THORNAME
+        description: "The THORName identifier for the affiliate"
+        tests:
+          - not_null
+      - name: EVENT_ID
+        description: "Unique identifier for the affiliate fee event"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_AFFILIATE_FEE_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/silver/silver__affiliate_fee_events.sql
+++ b/models/silver/silver__affiliate_fee_events.sql
@@ -1,0 +1,25 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+  tx_id,
+  fee_amt,
+  gross_amt,
+  fee_bps,
+  memo,
+  asset,
+  rune_address,
+  thorname,
+  event_id,
+  block_timestamp,
+  DATEADD(
+    ms,
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _INSERTED_TIMESTAMP
+FROM 
+  {{ ref('bronze__affiliate_fee_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id, tx_id, fee_amt, gross_amt, fee_bps, memo, asset, rune_address, thorname, block_timestamp
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1

--- a/models/silver/silver__affiliate_fee_events.yml
+++ b/models/silver/silver__affiliate_fee_events.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: silver__affiliate_fee_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - BLOCK_TIMESTAMP
+    columns:
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: FEE_AMT
+        tests:
+          - not_null
+      - name: GROSS_AMT
+        tests:
+          - not_null
+      - name: FEE_BPS
+        tests:
+          - not_null
+      - name: MEMO
+        tests:
+          - not_null
+      - name: ASSET
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        tests:
+          - not_null
+      - name: THORNAME
+        tests:
+          - not_null
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -3,10 +3,11 @@ version: 2
 sources:
   - name: thorchain_midgard
     database: HEVO
-    schema: THORCHAIN_MIDGARD_2_28_1
+    schema: THORCHAIN_MIDGARD_2_29_0_DRAB
     tables:
       - name: midgard_active_vault_events
       - name: midgard_add_events
+      - name: midgard_affiliate_fee_events
       - name: midgard_asgard_fund_yggdrasil_events
       - name: midgard_block_log
       - name: midgard_block_pool_depths


### PR DESCRIPTION
- Adds bronze, silver, and gold models for `affiliate_fee_events`
- Adds documentation and tests for silver and gold models for `affiliate_fee_events`
- Bumps version to 2.29.0
- Modifies `sources.yml` to new Hevo schema and adds `midgard_affiliate_fee_events` source