### PR TITLE
remove strict tests for silver upgrades

### DIFF
--- a/models/silver/silver__upgrades.yml
+++ b/models/silver/silver__upgrades.yml
@@ -32,13 +32,7 @@ models:
         tests:
           - not_null
       - name: RUNE_AMOUNT_USD
-        tests:
-          - not_null:
-              where: BLOCK_TIMESTAMP <= current_date -2 AND BLOCK_TIMESTAMP >= '2021-04-13'
       - name: MINT_AMOUNT
         tests:
           - not_null
       - name: MINT_AMOUNT_USD
-        tests:
-          - not_null:
-              where: BLOCK_TIMESTAMP <= current_date -2 AND BLOCK_TIMESTAMP >= '2021-04-13'


### PR DESCRIPTION
On rare occasion, price data from `silver.prices` is null. This happened in April 2021 and again on July 5, 2025:
```sql
select * 
from thorchain.defi.fact_upgrades 
where rune_amount_usd is null 
or mint_amount_usd is null
order by block_timestamp desc;
```
_result set: 14 rows_

Given the consistency of this model, I propose removing these tests to resolve alerting.