### PR TITLE
added new models from midgard upgrade

### DIFF
--- a/models/bronze/bronze__instantiate_events.sql
+++ b/models/bronze/bronze__instantiate_events.sql
@@ -1,0 +1,25 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    contract_address,
+    admin_address,
+    code_id,
+    sender,
+    label,
+    msg,
+    funds,
+    event_id,
+    block_timestamp,
+  __HEVO__DATABASE_NAME,
+  __HEVO__SCHEMA_NAME,
+  __HEVO__INGESTED_AT,
+  __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_instantiate_events'
+  ) }}
+

--- a/models/bronze/bronze__tcy_claim_events.sql
+++ b/models/bronze/bronze__tcy_claim_events.sql
@@ -1,0 +1,22 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    rune_address,
+    l1_address,
+    asset,
+    tcy_amt,
+    memo,
+    event_id,
+    block_timestamp,
+    __HEVO__DATABASE_NAME,
+    __HEVO__SCHEMA_NAME,
+    __HEVO__INGESTED_AT,
+    __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_tcy_claim_events'
+  ) }}

--- a/models/bronze/bronze__tcy_distribution_events.sql
+++ b/models/bronze/bronze__tcy_distribution_events.sql
@@ -1,0 +1,19 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    rune_address,
+    rune_amt,
+    event_id,
+    block_timestamp,
+    __HEVO__DATABASE_NAME,
+    __HEVO__SCHEMA_NAME,
+    __HEVO__INGESTED_AT,
+    __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_tcy_distribution_events'
+  ) }}
+

--- a/models/bronze/bronze__tcy_stake_events.sql
+++ b/models/bronze/bronze__tcy_stake_events.sql
@@ -1,0 +1,20 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    __HEVO__DATABASE_NAME,
+    __HEVO__SCHEMA_NAME,
+    __HEVO__INGESTED_AT,
+    __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_tcy_stake_events'
+  ) }}

--- a/models/bronze/bronze__tcy_unstake_events.sql
+++ b/models/bronze/bronze__tcy_unstake_events.sql
@@ -1,0 +1,20 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    __HEVO__DATABASE_NAME,
+    __HEVO__SCHEMA_NAME,
+    __HEVO__INGESTED_AT,
+    __HEVO__LOADED_AT
+FROM
+  {{ source(
+    'thorchain_midgard',
+    'midgard_tcy_unstake_events'
+  ) }}

--- a/models/descriptions/__overview__.md
+++ b/models/descriptions/__overview__.md
@@ -24,6 +24,7 @@ There is more information on how to use dbt docs in the last section of this doc
 - [core.dim_block](#!/model/model.thorchain_models.core__dim_block)
 - [core.dim_labels](#!/model/model.thorchain_models.core__dim_labels)
 - [core.dim_midgard](#!/model/model.thorchain_models.core__dim_midgard)
+- [core.fact_instantiate_events](#!/model/model.thorchain_models.core__fact_instantiate_events)
 - [core.fact_network_version_events](#!/model/model.thorchain_models.core__fact_network_version_events)
 - [core.fact_set_mimir_events](#!/model/model.thorchain_models.core__fact_set_mimir_events)
 - [core.fact_thorname_change_events](#!/model/model.thorchain_models.core__fact_thorname_change_events)
@@ -77,6 +78,10 @@ There is more information on how to use dbt docs in the last section of this doc
 - [defi.fact_swaps](#!/model/model.thorchain_models.defi__fact_swaps)
 - [defi.fact_swaps_events](#!/model/model.thorchain_models.defi__fact_swaps_events)
 - [defi.fact_switch_events](#!/model/model.thorchain_models.defi__fact_switch_events)
+- [defi.fact_tcy_claim_events](#!/model/model.thorchain_models.defi__fact_tcy_claim_events)
+- [defi.fact_tcy_distribution_events](#!/model/model.thorchain_models.defi__fact_tcy_distribution_events)
+- [defi.fact_tcy_stake_events](#!/model/model.thorchain_models.defi__fact_tcy_stake_events)
+- [defi.fact_tcy_unstake_events](#!/model/model.thorchain_models.defi__fact_tcy_unstake_events)
 - [defi.fact_total_block_rewards](#!/model/model.thorchain_models.defi__fact_total_block_rewards)
 - [defi.fact_total_value_locked](#!/model/model.thorchain_models.defi__fact_total_value_locked)
 - [defi.fact_trade_account_deposit_events](#!/model/model.thorchain_models.defi__fact_trade_account_deposit_events)
@@ -116,6 +121,7 @@ While THORchain models are built a few different ways, they are organized into t
 The dimension tables are sourced from a variety of on-chain and off-chain sources.
 
 Convenience views (denoted ez\_) are a combination of different fact and dimension tables. These views are built to make it easier to query the data.
+
 
 ## **Using dbt docs**
 

--- a/models/gold/core/core__fact_instantiate_events.sql
+++ b/models/gold/core/core__fact_instantiate_events.sql
@@ -1,0 +1,64 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'FACT_INSTANTIATE_EVENTS_ID',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    tx_id,
+    contract_address,
+    admin_address,
+    code_id,
+    sender,
+    label,
+    msg,
+    funds,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__instantiate_events') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.contract_address','a.block_timestamp']
+  ) }} AS FACT_INSTANTIATE_EVENTS_ID,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  A.tx_id,
+  A.contract_address,
+  A.admin_address,
+  A.code_id,
+  A.sender,
+  A.label,
+  A.msg,
+  A.funds,
+  A.event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/core/core__fact_instantiate_events.yml
+++ b/models/gold/core/core__fact_instantiate_events.yml
@@ -1,0 +1,55 @@
+version: 2
+models:
+  - name: core__fact_instantiate_events
+    description: "Comprehensive fact table tracking smart contract instantiation events on THORchain blockchain. This table captures detailed information about new smart contract deployments including contract addresses, admin addresses, code IDs, senders, labels, initialization messages, and funding details. Essential for monitoring THORchain ecosystem development, tracking contract creation patterns, analyzing developer activity, and understanding the growth and evolution of the smart contract landscape. Each record represents a unique contract instantiation event with complete deployment metadata for thorough blockchain development analysis and ecosystem monitoring."
+    columns:
+      - name: FACT_INSTANTIATE_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "FK to DIM_BLOCK table"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+      - name: CONTRACT_ADDRESS
+        description: "The contract address"
+        tests:
+          - not_null
+      - name: ADMIN_ADDRESS
+        description: "The admin address"
+      - name: CODE_ID
+        description: "The code ID"
+        tests:
+          - not_null
+      - name: SENDER
+        description: "{{ doc('from_address') }}"
+      - name: LABEL
+        description: "The label"
+      - name: MSG
+        description: "The message"
+      - name: FUNDS
+        description: "The funds"
+      - name: EVENT_ID
+        description: "{{ doc('id') }}"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_INSTANTIATE_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/gold/defi/defi__fact_tcy_claim_events.sql
+++ b/models/gold/defi/defi__fact_tcy_claim_events.sql
@@ -1,0 +1,60 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_tcy_claim_events_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    tx_id,
+    rune_address,
+    l1_address,
+    asset,
+    tcy_amt,
+    memo,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__tcy_claim_events') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.tx_id','a.rune_address','a.l1_address','a.asset']
+  ) }} AS fact_tcy_claim_events_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  tx_id,
+  rune_address,
+  l1_address,
+  asset,
+  tcy_amt,
+  memo,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_tcy_claim_events.yml
+++ b/models/gold/defi/defi__fact_tcy_claim_events.yml
@@ -1,0 +1,57 @@
+version: 2
+models:
+  - name: defi__fact_tcy_claim_events
+    description: "Comprehensive fact table tracking THORchain Yield (TCY) reward claim events and transactions. This table captures detailed information about users claiming their earned TCY rewards including transaction IDs, claimed TCY amounts, asset types, RUNE addresses, L1 addresses for cross-chain operations, memo fields, and precise timing information. Essential for yield analysis and reward distribution tracking, understanding user claiming behavior patterns, calculating total rewards distributed, and analyzing cross-chain reward mechanics. Each record represents a unique TCY reward claim transaction with complete user and transaction metadata for thorough yield farming analysis, reward distribution monitoring, and protocol performance evaluation."
+    columns:
+      - name: FACT_TCY_CLAIM_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "FK to DIM_BLOCK table"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        description: "{{ doc('address') }}"
+        tests:
+          - not_null
+      - name: L1_ADDRESS
+        description: "The L1 address"
+        tests:
+          - not_null
+      - name: ASSET
+        description: "{{ doc('asset') }}"
+        tests:
+          - not_null
+      - name: TCY_AMT
+        description: "The TCY amount"
+        tests:
+          - not_null
+      - name: MEMO
+        description: "{{ doc('memo') }}"
+      - name: EVENT_ID
+        description: "{{ doc('id') }}"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_TCY_CLAIM_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/gold/defi/defi__fact_tcy_distribution_events.sql
+++ b/models/gold/defi/defi__fact_tcy_distribution_events.sql
@@ -1,0 +1,52 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_tcy_distribution_events_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    rune_address,
+    rune_amt,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__tcy_distribution_events') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.rune_address','a.rune_amt']
+  ) }} AS fact_tcy_distribution_events_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  rune_address,
+  rune_amt,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_tcy_distribution_events.yml
+++ b/models/gold/defi/defi__fact_tcy_distribution_events.yml
@@ -1,0 +1,43 @@
+version: 2
+models:
+  - name: defi__fact_tcy_distribution_events
+    description: "Comprehensive fact table tracking THORchain Yield (TCY) automatic reward distribution events and transactions. This table captures detailed information about protocol-level reward distributions to users including RUNE addresses, distribution amounts, and precise timing information. Essential for tracking protocol-level reward mechanisms, calculating total distributed yields across the ecosystem, analyzing reward distribution patterns and frequencies, and monitoring the overall health of the TCY reward system. Each record represents a unique TCY reward distribution event with complete recipient and transaction metadata for thorough yield farming analysis, reward distribution monitoring, and protocol performance evaluation."
+    columns:
+      - name: FACT_TCY_DISTRIBUTION_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "FK to DIM_BLOCK table"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: RUNE_ADDRESS
+        description: "{{ doc('address') }}"
+        tests:
+          - not_null
+      - name: RUNE_AMT
+        description: "The RUNE amount"
+        tests:
+          - not_null
+      - name: EVENT_ID
+        description: "{{ doc('id') }}"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_TCY_DISTRIBUTION_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/gold/defi/defi__fact_tcy_stake_events.sql
+++ b/models/gold/defi/defi__fact_tcy_stake_events.sql
@@ -1,0 +1,56 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_tcy_stake_events_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__tcy_stake_events') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.tx_id','a.rune_address','a.memo']
+  ) }} AS fact_tcy_stake_events_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  tx_id,
+  rune_address,
+  amount,
+  memo,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_tcy_stake_events.yml
+++ b/models/gold/defi/defi__fact_tcy_stake_events.yml
@@ -1,0 +1,49 @@
+version: 2
+models:
+  - name: defi__fact_tcy_stake_events
+    description: "Comprehensive fact table tracking THORchain Yield (TCY) staking events and transactions. This table captures detailed information about user staking activities including transaction IDs, staked amounts, RUNE addresses, memo fields, and precise timing information. Essential for analyzing user staking behavior patterns, calculating total value locked (TVL) in TCY pools, measuring staking trends over time, and understanding liquidity provision dynamics. Each record represents a unique TCY staking transaction with complete user and transaction metadata for thorough yield farming analysis, user behavior tracking, and protocol performance monitoring."
+    columns:
+      - name: FACT_TCY_STAKE_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "FK to DIM_BLOCK table"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        description: "{{ doc('address') }}"
+        tests:
+          - not_null
+      - name: AMOUNT
+        description: "The amount"
+        tests:
+          - not_null
+      - name: MEMO
+        description: "{{ doc('memo') }}"
+      - name: EVENT_ID
+        description: "{{ doc('id') }}"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_TCY_STAKE_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/gold/defi/defi__fact_tcy_unstake_events.sql
+++ b/models/gold/defi/defi__fact_tcy_unstake_events.sql
@@ -1,0 +1,56 @@
+{{ config(
+  materialized = 'incremental',
+  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, AMM' }} },
+  unique_key = 'fact_tcy_unstake_events_id',
+  incremental_strategy = 'merge',
+  incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ')'],  
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base AS (
+
+  SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__tcy_unstake_events') }}
+)
+SELECT
+  {{ dbt_utils.generate_surrogate_key(
+    ['a.event_id','a.tx_id','a.rune_address','a.memo']
+  ) }} AS fact_tcy_unstake_events_id,
+  b.block_timestamp,
+  COALESCE(
+    b.dim_block_id,
+    '-1'
+  ) AS dim_block_id,
+  tx_id,
+  amount,
+  rune_address,
+  memo,
+  event_id,
+  A._INSERTED_TIMESTAMP,
+  '{{ invocation_id }}' AS _audit_run_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp
+FROM
+  base A
+  JOIN {{ ref('core__dim_block') }}
+  b
+  ON A.block_timestamp = b.timestamp
+{% if is_incremental() %}
+WHERE
+  b.block_timestamp >= (
+    SELECT
+      MAX(
+        block_timestamp - INTERVAL '1 HOUR'
+      )
+    FROM
+      {{ this }}
+  ) 
+{% endif %}

--- a/models/gold/defi/defi__fact_tcy_unstake_events.yml
+++ b/models/gold/defi/defi__fact_tcy_unstake_events.yml
@@ -1,0 +1,49 @@
+version: 2
+models:
+  - name: defi__fact_tcy_unstake_events
+    description: "Comprehensive fact table tracking THORchain Yield (TCY) unstaking events and withdrawal transactions. This table captures detailed information about users withdrawing their staked assets from TCY pools including transaction IDs, unstaked amounts, RUNE addresses, memo fields, and precise timing information. Essential for calculating actual yield earned by users, understanding user exit patterns and behaviors, measuring pool retention rates, and analyzing the lifecycle of TCY staking positions. Each record represents a unique TCY unstaking transaction with complete user and transaction metadata for thorough yield farming analysis, liquidity flow tracking, and protocol performance monitoring."
+    columns:
+      - name: FACT_TCY_UNSTAKE_EVENTS_ID
+        description: "{{ doc('sk') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - unique
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: DIM_BLOCK_ID not in ('-1','-2')
+      - name: DIM_BLOCK_ID
+        description: "FK to DIM_BLOCK table"
+        tests:
+          - negative_one:
+              where: _inserted_timestamp <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: AMOUNT
+        description: "The amount"
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        description: "{{ doc('address') }}"
+        tests:
+          - not_null
+      - name: MEMO
+        description: "{{ doc('memo') }}"
+      - name: EVENT_ID
+        description: "{{ doc('id') }}"
+        tests:
+          - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
+    tests:
+      - dbt_constraints.primary_key:
+          column_name: FACT_TCY_UNSTAKE_EVENTS_ID
+      - dbt_constraints.foreign_key:
+          fk_column_name: DIM_BLOCK_ID
+          pk_table_name: ref('core__dim_block')
+          pk_column_name: DIM_BLOCK_ID

--- a/models/silver/silver__instantiate_events.sql
+++ b/models/silver/silver__instantiate_events.sql
@@ -1,0 +1,26 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    contract_address,
+    admin_address,
+    code_id,
+    sender,
+    label,
+    msg,
+    funds,
+    event_id,
+    block_timestamp,
+    DATEADD(
+      ms,
+      __HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _INSERTED_TIMESTAMP
+FROM
+  {{ ref('bronze__instantiate_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1
+

--- a/models/silver/silver__instantiate_events.yml
+++ b/models/silver/silver__instantiate_events.yml
@@ -1,0 +1,31 @@
+version: 2
+models:
+  - name: silver__instantiate_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - CONTRACT_ADDRESS
+            - BLOCK_TIMESTAMP
+    columns:
+      - name: TX_ID
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+      - name: ADMIN_ADDRESS
+      - name: CODE_ID
+        tests:
+          - not_null
+      - name: SENDER
+      - name: LABEL
+      - name: MSG
+      - name: FUNDS
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/silver/silver__tcy_claim_events.sql
+++ b/models/silver/silver__tcy_claim_events.sql
@@ -1,0 +1,23 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    rune_address,
+    l1_address,
+    asset,
+    tcy_amt,
+    memo,
+    event_id,
+    block_timestamp,
+    DATEADD(
+    ms,
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _INSERTED_TIMESTAMP
+FROM
+  {{ ref('bronze__tcy_claim_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1

--- a/models/silver/silver__tcy_claim_events.yml
+++ b/models/silver/silver__tcy_claim_events.yml
@@ -1,0 +1,35 @@
+version: 2
+models:
+  - name: silver__tcy_claim_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - TX_ID
+            - RUNE_ADDRESS
+    columns:
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        tests:
+          - not_null
+      - name: L1_ADDRESS
+        tests:
+          - not_null
+      - name: ASSET
+        tests:
+          - not_null
+      - name: TCY_AMT
+        tests:
+          - not_null
+      - name: MEMO
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/silver/silver__tcy_distribution_events.sql
+++ b/models/silver/silver__tcy_distribution_events.sql
@@ -1,0 +1,20 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    rune_address,
+    rune_amt,
+    event_id,
+    block_timestamp,
+    DATEADD(
+        ms,
+        __HEVO__LOADED_AT,
+        '1970-01-01'
+    ) AS _INSERTED_TIMESTAMP
+FROM
+    {{ ref('bronze__tcy_distribution_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1
+

--- a/models/silver/silver__tcy_distribution_events.yml
+++ b/models/silver/silver__tcy_distribution_events.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: silver__tcy_distribution_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - RUNE_ADDRESS
+            - RUNE_AMT
+    columns:
+      - name: RUNE_ADDRESS
+        tests:
+          - not_null
+      - name: RUNE_AMT
+        tests:
+          - not_null
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/silver/silver__tcy_stake_events.sql
+++ b/models/silver/silver__tcy_stake_events.sql
@@ -1,0 +1,21 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    DATEADD(
+        ms,
+        __HEVO__LOADED_AT,
+        '1970-01-01'
+    ) AS _INSERTED_TIMESTAMP
+FROM
+  {{ ref('bronze__tcy_stake_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1

--- a/models/silver/silver__tcy_stake_events.yml
+++ b/models/silver/silver__tcy_stake_events.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: silver__tcy_stake_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - TX_ID
+            - RUNE_ADDRESS
+    columns:
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        tests:
+          - not_null
+      - name: MEMO
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/silver/silver__tcy_unstake_events.sql
+++ b/models/silver/silver__tcy_unstake_events.sql
@@ -1,0 +1,21 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    tx_id,
+    amount,
+    rune_address,
+    memo,
+    event_id,
+    block_timestamp,
+    DATEADD(
+        ms,
+        __HEVO__LOADED_AT,
+        '1970-01-01'
+    ) AS _INSERTED_TIMESTAMP
+FROM
+  {{ ref('bronze__tcy_unstake_events') }}
+  qualify(ROW_NUMBER() over(PARTITION BY event_id
+ORDER BY
+  __HEVO__LOADED_AT DESC)) = 1

--- a/models/silver/silver__tcy_unstake_events.yml
+++ b/models/silver/silver__tcy_unstake_events.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: silver__tcy_unstake_events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - EVENT_ID
+            - TX_ID
+            - RUNE_ADDRESS
+    columns:
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+      - name: RUNE_ADDRESS
+        tests:
+          - not_null
+      - name: MEMO
+      - name: EVENT_ID
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -18,6 +18,7 @@ sources:
       - name: midgard_fee_events
       - name: midgard_gas_events
       - name: midgard_inactive_vault_events
+      - name: midgard_instantiate_events
       - name: midgard_loan_open_events
       - name: midgard_loan_repayment_events
       - name: midgard_mint_burn_events
@@ -49,6 +50,10 @@ sources:
       - name: midgard_streaming_swap_details_events
       - name: midgard_swap_events
       - name: midgard_switch_events
+      - name: midgard_tcy_claim_events
+      - name: midgard_tcy_distribution_events
+      - name: midgard_tcy_stake_events
+      - name: midgard_tcy_unstake_events
       - name: midgard_thorname_change_events
       - name: midgard_trade_account_deposit_events
       - name: midgard_trade_account_withdraw_events


### PR DESCRIPTION
Adding bronze/silver/gold layers for 5 new models introduced with the latest Midgard upgrade. These follow typical dev patterns for THORchain with minimal transformations.

Eric created these in dev with different permissions, so I overconfidently built them in prod without grants. 

Build:
```sql
dbt run -s bronze__instantiate_events bronze__tcy_claim_events bronze__tcy_distribution_events bronze__tcy_stake_events bronze__tcy_unstake_events silver__instantiate_events silver__tcy_claim_events silver__tcy_distribution_events silver__tcy_stake_events silver__tcy_unstake_events core__fact_instantiate_events defi__fact_tcy_claim_events defi__fact_tcy_distribution_events defi__fact_tcy_stake_events defi__fact_tcy_unstake_events -t prod
```
Test:
```sql
dbt test -s silver__instantiate_events silver__tcy_claim_events silver__tcy_distribution_events silver__tcy_stake_events silver__tcy_unstake_events core__fact_instantiate_events defi__fact_tcy_claim_events defi__fact_tcy_distribution_events defi__fact_tcy_stake_events defi__fact_tcy_unstake_events -t prod
```