### PR TITLE
fix and update issues causing alerts

### DIFF
--- a/models/silver/silver__total_block_rewards.sql
+++ b/models/silver/silver__total_block_rewards.sql
@@ -8,7 +8,7 @@
 WITH block_prices AS (
 
   SELECT
-    AVG(rune_usd) AS rune_usd,
+    COALESCE(AVG(rune_usd), 0) AS rune_usd,
     block_id
   FROM
     {{ ref('silver__prices') }}
@@ -21,7 +21,7 @@ fin AS (
     b.height AS block_id,
     ree.pool_name AS reward_entity,
     COALESCE(rune_e8 / pow(10, 8), 0) AS rune_amount,
-    COALESCE(rune_e8 / pow(10, 8) * rune_usd, 0) AS rune_amount_usd,
+    COALESCE(rune_e8 / pow(10, 8) * COALESCE(rune_usd, 0), 0) AS rune_amount_usd,
     concat_ws(
       '-',
       b.height,
@@ -76,7 +76,7 @@ SELECT
   bond_e8 / pow(
     10,
     8
-  ) * rune_usd AS rune_amount_usd,
+  ) * COALESCE(rune_usd, 0) AS rune_amount_usd,
   concat_ws(
     '-',
     b.height,

--- a/models/silver/silver__wasm_contracts_events.yml
+++ b/models/silver/silver__wasm_contracts_events.yml
@@ -20,8 +20,6 @@ models:
           - not_null
       - name: SENDER
       - name: ATTRIBUTES
-        tests:
-          - not_null
       - name: EVENT_ID
         tests:
           - not_null

--- a/tests/tests__fact_prices__block_id-assert_no_gaps.sql
+++ b/tests/tests__fact_prices__block_id-assert_no_gaps.sql
@@ -1,1 +1,5 @@
+{{ config(
+    warn_if = "> 10",
+    severity = "warn"
+) }}
 {{ sequence_distinct_gaps_dim_block_id(ref("price__fact_prices"), "block_id") }}


### PR DESCRIPTION
* Add `coalesce()` to total block rewards, as rewards can occasionally be 0
* Remove generic null test for wasm contract events, as `contract_type = wasm-calc-strategy/execute` produces nulls
* Switch gap test to a warning, as the price model filters out some prices. See filters: `rune_e8 > 0 AND asset_e8 > 0 `